### PR TITLE
Fix build output filenames

### DIFF
--- a/opt/build.sh
+++ b/opt/build.sh
@@ -124,7 +124,9 @@ build_image() {
   # if successful, mv seedsigner_os.img image to /images
   # rename to image to include branch name and config name, then compress
   
-  seedsigner_os_image_output="${image_dir}/seedsigner_os.${seedsigner_app_repo_branch}.${config_name}.img"
+  # Sanitize branch name so that it is safe for filenames
+  sanitized_branch=$(echo "${seedsigner_app_repo_branch}" | tr -c 'A-Za-z0-9_.-' '_')
+  seedsigner_os_image_output="${image_dir}/seedsigner_os.${sanitized_branch}.${config_name}.img"
   if ! [ -z ${seedsigner_app_repo_commit_id} ]; then
     # use commit id instead of branch name if it is set
     seedsigner_os_image_output="${image_dir}/seedsigner_os.${seedsigner_app_repo_commit_id}.${config_name}.img"


### PR DESCRIPTION
## Summary
- sanitize branch names used in build output filenames

## Testing
- `bash -n opt/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6882deff6fb883228292b805fc35cbdf