### PR TITLE
Update to SeedSigner 0.8.6 images

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -53,7 +53,7 @@ export RELEASE_TAG=x.y.z
 
 ```
 
-Checkout the branch associated to the target release version of the SeedSigner code (e.g. 0.8.5, 0.8.0, etc)
+Checkout the branch associated to the target release version of the SeedSigner code (e.g. 0.8.6, 0.8.0, etc)
 ```bash
 git checkout $RELEASE_TAG
 ```
@@ -98,7 +98,7 @@ Set your target release version of the SeedSigner code (see: https://github.com/
 $env:RELEASE_TAG = "x.y.z"  
 ```
 
-Checkout the branch associated to the target release version of the SeedSigner code (e.g. 0.8.5, 0.8.0, etc)
+Checkout the branch associated to the target release version of the SeedSigner code (e.g. 0.8.6, 0.8.0, etc)
 ```powershell
 git checkout $env:RELEASE_TAG
 ```

--- a/opt/pi0-smartcard-dev/board/genimage-rpi-seedsigner.cfg
+++ b/opt/pi0-smartcard-dev/board/genimage-rpi-seedsigner.cfg
@@ -15,20 +15,20 @@ image boot.vfat {
 	"diy-tools.squashfs"
     }
 	
-	file microsd-images/seedsigner_os.0.8.5.pi0.img {
-		image = "seedsigner_os.0.8.5.pi0.img"
+	file microsd-images/seedsigner_os.0.8.6.pi0.img {
+		image = "seedsigner_os.0.8.6.pi0.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi02w.img {
-		image = "seedsigner_os.0.8.5.pi02w.img"
+		file microsd-images/seedsigner_os.0.8.6.pi02w.img {
+		image = "seedsigner_os.0.8.6.pi02w.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi2.img {
-		image = "seedsigner_os.0.8.5.pi2.img"
+		file microsd-images/seedsigner_os.0.8.6.pi2.img {
+		image = "seedsigner_os.0.8.6.pi2.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi4.img {
-		image = "seedsigner_os.0.8.5.pi4.img"
+		file microsd-images/seedsigner_os.0.8.6.pi4.img {
+		image = "seedsigner_os.0.8.6.pi4.img"
 	}
 	
 		file javacard-cap/SeedKeeper-0.2-official.cap {

--- a/opt/pi0-smartcard-dev/board/post-image-seedsigner.sh
+++ b/opt/pi0-smartcard-dev/board/post-image-seedsigner.sh
@@ -57,17 +57,17 @@ sha256sum ./tmp/images/diy-tools.squashfs
 
 mv ./tmp/images/diy-tools.squashfs ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi0.img
-mv seedsigner_os.0.8.5.pi0.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi0.img
+mv seedsigner_os.0.8.6.pi0.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi02w.img
-mv seedsigner_os.0.8.5.pi02w.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi02w.img
+mv seedsigner_os.0.8.6.pi02w.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi2.img
-mv seedsigner_os.0.8.5.pi2.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi2.img
+mv seedsigner_os.0.8.6.pi2.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi4.img
-mv seedsigner_os.0.8.5.pi4.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi4.img
+mv seedsigner_os.0.8.6.pi4.img ${BINARIES_DIR}
 
 wget https://github.com/Toporin/Seedkeeper-Applet/releases/download/v0.2-0.1/SeedKeeper-v0.2-0.1.cap
 mv SeedKeeper-v0.2-0.1.cap ${BINARIES_DIR}

--- a/opt/pi0-smartcard/board/post-image-seedsigner.sh
+++ b/opt/pi0-smartcard/board/post-image-seedsigner.sh
@@ -57,17 +57,17 @@ sha256sum ./tmp/images/diy-tools.squashfs
 
 mv ./tmp/images/diy-tools.squashfs ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi0.img
-mv seedsigner_os.0.8.5.pi0.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi0.img
+mv seedsigner_os.0.8.6.pi0.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi02w.img
-mv seedsigner_os.0.8.5.pi02w.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi02w.img
+mv seedsigner_os.0.8.6.pi02w.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi2.img
-mv seedsigner_os.0.8.5.pi2.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi2.img
+mv seedsigner_os.0.8.6.pi2.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi4.img
-mv seedsigner_os.0.8.5.pi4.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi4.img
+mv seedsigner_os.0.8.6.pi4.img ${BINARIES_DIR}
 
 wget https://github.com/Toporin/Seedkeeper-Applet/releases/download/v0.2-0.1/SeedKeeper-v0.2-0.1.cap
 mv SeedKeeper-v0.2-0.1.cap ${BINARIES_DIR}
@@ -144,10 +144,10 @@ cp ${BINARIES_DIR}/diy-tools.squashfs boot/diy-tools.squashfs
 
 # Copy Seedsigner Images
 mkdir -p boot/microsd-images microsd-images
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi0.img microsd-images/seedsigner_os.0.8.5.pi0.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi02w.img microsd-images/seedsigner_os.0.8.5.pi02w.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi2.img microsd-images/seedsigner_os.0.8.5.pi2.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi4.img microsd-images/seedsigner_os.0.8.5.pi4.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi0.img microsd-images/seedsigner_os.0.8.6.pi0.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi02w.img microsd-images/seedsigner_os.0.8.6.pi02w.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi2.img microsd-images/seedsigner_os.0.8.6.pi2.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi4.img microsd-images/seedsigner_os.0.8.6.pi4.img
 
 # Copy Pre-Compiled CAP files
 mkdir -p boot/javacard-cap javacard-cap

--- a/opt/pi02w-smartcard-dev/board/genimage-rpi-seedsigner.cfg
+++ b/opt/pi02w-smartcard-dev/board/genimage-rpi-seedsigner.cfg
@@ -15,20 +15,20 @@ image boot.vfat {
 	  "diy-tools.squashfs"
     }
 	
-	file microsd-images/seedsigner_os.0.8.5.pi0.img {
-		image = "seedsigner_os.0.8.5.pi0.img"
+	file microsd-images/seedsigner_os.0.8.6.pi0.img {
+		image = "seedsigner_os.0.8.6.pi0.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi02w.img {
-		image = "seedsigner_os.0.8.5.pi02w.img"
+		file microsd-images/seedsigner_os.0.8.6.pi02w.img {
+		image = "seedsigner_os.0.8.6.pi02w.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi2.img {
-		image = "seedsigner_os.0.8.5.pi2.img"
+		file microsd-images/seedsigner_os.0.8.6.pi2.img {
+		image = "seedsigner_os.0.8.6.pi2.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi4.img {
-		image = "seedsigner_os.0.8.5.pi4.img"
+		file microsd-images/seedsigner_os.0.8.6.pi4.img {
+		image = "seedsigner_os.0.8.6.pi4.img"
 	}
 	
 		file javacard-cap/SeedKeeper-0.2-official.cap {

--- a/opt/pi02w-smartcard-dev/board/post-image-seedsigner.sh
+++ b/opt/pi02w-smartcard-dev/board/post-image-seedsigner.sh
@@ -57,17 +57,17 @@ sha256sum ./tmp/images/diy-tools.squashfs
 
 mv ./tmp/images/diy-tools.squashfs ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi0.img
-mv seedsigner_os.0.8.5.pi0.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi0.img
+mv seedsigner_os.0.8.6.pi0.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi02w.img
-mv seedsigner_os.0.8.5.pi02w.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi02w.img
+mv seedsigner_os.0.8.6.pi02w.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi2.img
-mv seedsigner_os.0.8.5.pi2.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi2.img
+mv seedsigner_os.0.8.6.pi2.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi4.img
-mv seedsigner_os.0.8.5.pi4.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi4.img
+mv seedsigner_os.0.8.6.pi4.img ${BINARIES_DIR}
 
 wget https://github.com/Toporin/Seedkeeper-Applet/releases/download/v0.2-0.1/SeedKeeper-v0.2-0.1.cap
 mv SeedKeeper-v0.2-0.1.cap ${BINARIES_DIR}

--- a/opt/pi02w-smartcard/board/post-image-seedsigner.sh
+++ b/opt/pi02w-smartcard/board/post-image-seedsigner.sh
@@ -57,17 +57,17 @@ sha256sum ./tmp/images/diy-tools.squashfs
 
 mv ./tmp/images/diy-tools.squashfs ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi0.img
-mv seedsigner_os.0.8.5.pi0.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi0.img
+mv seedsigner_os.0.8.6.pi0.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi02w.img
-mv seedsigner_os.0.8.5.pi02w.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi02w.img
+mv seedsigner_os.0.8.6.pi02w.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi2.img
-mv seedsigner_os.0.8.5.pi2.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi2.img
+mv seedsigner_os.0.8.6.pi2.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi4.img
-mv seedsigner_os.0.8.5.pi4.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi4.img
+mv seedsigner_os.0.8.6.pi4.img ${BINARIES_DIR}
 
 wget https://github.com/Toporin/Seedkeeper-Applet/releases/download/v0.2-0.1/SeedKeeper-v0.2-0.1.cap
 mv SeedKeeper-v0.2-0.1.cap ${BINARIES_DIR}
@@ -144,10 +144,10 @@ cp ${BINARIES_DIR}/diy-tools.squashfs boot/diy-tools.squashfs
 
 # Copy Seedsigner Images
 mkdir -p boot/microsd-images microsd-images
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi0.img microsd-images/seedsigner_os.0.8.5.pi0.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi02w.img microsd-images/seedsigner_os.0.8.5.pi02w.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi2.img microsd-images/seedsigner_os.0.8.5.pi2.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi4.img microsd-images/seedsigner_os.0.8.5.pi4.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi0.img microsd-images/seedsigner_os.0.8.6.pi0.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi02w.img microsd-images/seedsigner_os.0.8.6.pi02w.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi2.img microsd-images/seedsigner_os.0.8.6.pi2.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi4.img microsd-images/seedsigner_os.0.8.6.pi4.img
 
 # Copy Pre-Compiled CAP files
 mkdir -p boot/javacard-cap javacard-cap

--- a/opt/pi2-smartcard-dev/board/genimage-rpi-seedsigner.cfg
+++ b/opt/pi2-smartcard-dev/board/genimage-rpi-seedsigner.cfg
@@ -12,20 +12,20 @@ image boot.vfat {
 	"diy-tools.squashfs"
     }
 	
-	file microsd-images/seedsigner_os.0.8.5.pi0.img {
-		image = "seedsigner_os.0.8.5.pi0.img"
+	file microsd-images/seedsigner_os.0.8.6.pi0.img {
+		image = "seedsigner_os.0.8.6.pi0.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi02w.img {
-		image = "seedsigner_os.0.8.5.pi02w.img"
+		file microsd-images/seedsigner_os.0.8.6.pi02w.img {
+		image = "seedsigner_os.0.8.6.pi02w.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi2.img {
-		image = "seedsigner_os.0.8.5.pi2.img"
+		file microsd-images/seedsigner_os.0.8.6.pi2.img {
+		image = "seedsigner_os.0.8.6.pi2.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi4.img {
-		image = "seedsigner_os.0.8.5.pi4.img"
+		file microsd-images/seedsigner_os.0.8.6.pi4.img {
+		image = "seedsigner_os.0.8.6.pi4.img"
 	}
 	
 		file javacard-cap/SeedKeeper-0.2-official.cap {

--- a/opt/pi2-smartcard-dev/board/post-image-seedsigner.sh
+++ b/opt/pi2-smartcard-dev/board/post-image-seedsigner.sh
@@ -57,17 +57,17 @@ sha256sum ./tmp/images/diy-tools.squashfs
 
 mv ./tmp/images/diy-tools.squashfs ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi0.img
-mv seedsigner_os.0.8.5.pi0.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi0.img
+mv seedsigner_os.0.8.6.pi0.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi02w.img
-mv seedsigner_os.0.8.5.pi02w.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi02w.img
+mv seedsigner_os.0.8.6.pi02w.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi2.img
-mv seedsigner_os.0.8.5.pi2.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi2.img
+mv seedsigner_os.0.8.6.pi2.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi4.img
-mv seedsigner_os.0.8.5.pi4.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi4.img
+mv seedsigner_os.0.8.6.pi4.img ${BINARIES_DIR}
 
 wget https://github.com/Toporin/Seedkeeper-Applet/releases/download/v0.2-0.1/SeedKeeper-v0.2-0.1.cap
 mv SeedKeeper-v0.2-0.1.cap ${BINARIES_DIR}

--- a/opt/pi2-smartcard/board/post-image-seedsigner.sh
+++ b/opt/pi2-smartcard/board/post-image-seedsigner.sh
@@ -57,17 +57,17 @@ sha256sum ./tmp/images/diy-tools.squashfs
 
 mv ./tmp/images/diy-tools.squashfs ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi0.img
-mv seedsigner_os.0.8.5.pi0.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi0.img
+mv seedsigner_os.0.8.6.pi0.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi02w.img
-mv seedsigner_os.0.8.5.pi02w.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi02w.img
+mv seedsigner_os.0.8.6.pi02w.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi2.img
-mv seedsigner_os.0.8.5.pi2.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi2.img
+mv seedsigner_os.0.8.6.pi2.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi4.img
-mv seedsigner_os.0.8.5.pi4.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi4.img
+mv seedsigner_os.0.8.6.pi4.img ${BINARIES_DIR}
 
 wget https://github.com/Toporin/Seedkeeper-Applet/releases/download/v0.2-0.1/SeedKeeper-v0.2-0.1.cap
 mv SeedKeeper-v0.2-0.1.cap ${BINARIES_DIR}
@@ -144,10 +144,10 @@ cp ${BINARIES_DIR}/diy-tools.squashfs boot/diy-tools.squashfs
 
 # Copy Seedsigner Images
 mkdir -p boot/microsd-images microsd-images
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi0.img microsd-images/seedsigner_os.0.8.5.pi0.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi02w.img microsd-images/seedsigner_os.0.8.5.pi02w.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi2.img microsd-images/seedsigner_os.0.8.5.pi2.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi4.img microsd-images/seedsigner_os.0.8.5.pi4.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi0.img microsd-images/seedsigner_os.0.8.6.pi0.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi02w.img microsd-images/seedsigner_os.0.8.6.pi02w.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi2.img microsd-images/seedsigner_os.0.8.6.pi2.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi4.img microsd-images/seedsigner_os.0.8.6.pi4.img
 
 # Copy Pre-Compiled CAP files
 mkdir -p boot/javacard-cap javacard-cap

--- a/opt/pi4-smartcard-dev/board/genimage-rpi-seedsigner.cfg
+++ b/opt/pi4-smartcard-dev/board/genimage-rpi-seedsigner.cfg
@@ -12,20 +12,20 @@ image boot.vfat {
 	  "diy-tools.squashfs"
     }
 	
-	file microsd-images/seedsigner_os.0.8.5.pi0.img {
-		image = "seedsigner_os.0.8.5.pi0.img"
+	file microsd-images/seedsigner_os.0.8.6.pi0.img {
+		image = "seedsigner_os.0.8.6.pi0.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi02w.img {
-		image = "seedsigner_os.0.8.5.pi02w.img"
+		file microsd-images/seedsigner_os.0.8.6.pi02w.img {
+		image = "seedsigner_os.0.8.6.pi02w.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi2.img {
-		image = "seedsigner_os.0.8.5.pi2.img"
+		file microsd-images/seedsigner_os.0.8.6.pi2.img {
+		image = "seedsigner_os.0.8.6.pi2.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.8.5.pi4.img {
-		image = "seedsigner_os.0.8.5.pi4.img"
+		file microsd-images/seedsigner_os.0.8.6.pi4.img {
+		image = "seedsigner_os.0.8.6.pi4.img"
 	}
 	
 		file javacard-cap/SeedKeeper-0.2-official.cap {

--- a/opt/pi4-smartcard-dev/board/post-image-seedsigner.sh
+++ b/opt/pi4-smartcard-dev/board/post-image-seedsigner.sh
@@ -57,17 +57,17 @@ sha256sum ./tmp/images/diy-tools.squashfs
 
 mv ./tmp/images/diy-tools.squashfs ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi0.img
-mv seedsigner_os.0.8.5.pi0.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi0.img
+mv seedsigner_os.0.8.6.pi0.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi02w.img
-mv seedsigner_os.0.8.5.pi02w.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi02w.img
+mv seedsigner_os.0.8.6.pi02w.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi2.img
-mv seedsigner_os.0.8.5.pi2.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi2.img
+mv seedsigner_os.0.8.6.pi2.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi4.img
-mv seedsigner_os.0.8.5.pi4.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi4.img
+mv seedsigner_os.0.8.6.pi4.img ${BINARIES_DIR}
 
 wget https://github.com/Toporin/Seedkeeper-Applet/releases/download/v0.2-0.1/SeedKeeper-v0.2-0.1.cap
 mv SeedKeeper-v0.2-0.1.cap ${BINARIES_DIR}

--- a/opt/pi4-smartcard/board/genimage-rpi-seedsigner.cfg
+++ b/opt/pi4-smartcard/board/genimage-rpi-seedsigner.cfg
@@ -12,20 +12,20 @@ image boot.vfat {
 	  "diy-tools.squashfs"
     }
 	
-	file microsd-images/seedsigner_os.0.7.0.pi0.img {
-		image = "seedsigner_os.0.7.0.pi0.img"
+	file microsd-images/seedsigner_os.0.8.6.pi0.img {
+		image = "seedsigner_os.0.8.6.pi0.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.7.0.pi02w.img {
-		image = "seedsigner_os.0.7.0.pi02w.img"
+		file microsd-images/seedsigner_os.0.8.6.pi02w.img {
+		image = "seedsigner_os.0.8.6.pi02w.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.7.0.pi2.img {
-		image = "seedsigner_os.0.7.0.pi2.img"
+		file microsd-images/seedsigner_os.0.8.6.pi2.img {
+		image = "seedsigner_os.0.8.6.pi2.img"
 	}
 	
-		file microsd-images/seedsigner_os.0.7.0.pi4.img {
-		image = "seedsigner_os.0.7.0.pi4.img"
+		file microsd-images/seedsigner_os.0.8.6.pi4.img {
+		image = "seedsigner_os.0.8.6.pi4.img"
 	}
 	
 		file javacard-cap/SeedKeeper-0.1-official.cap {

--- a/opt/pi4-smartcard/board/post-image-seedsigner.sh
+++ b/opt/pi4-smartcard/board/post-image-seedsigner.sh
@@ -57,17 +57,17 @@ sha256sum ./tmp/images/diy-tools.squashfs
 
 mv ./tmp/images/diy-tools.squashfs ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi0.img
-mv seedsigner_os.0.8.5.pi0.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi0.img
+mv seedsigner_os.0.8.6.pi0.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi02w.img
-mv seedsigner_os.0.8.5.pi02w.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi02w.img
+mv seedsigner_os.0.8.6.pi02w.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi2.img
-mv seedsigner_os.0.8.5.pi2.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi2.img
+mv seedsigner_os.0.8.6.pi2.img ${BINARIES_DIR}
 
-wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.5/seedsigner_os.0.8.5.pi4.img
-mv seedsigner_os.0.8.5.pi4.img ${BINARIES_DIR}
+wget https://github.com/SeedSigner/seedsigner/releases/download/0.8.6/seedsigner_os.0.8.6.pi4.img
+mv seedsigner_os.0.8.6.pi4.img ${BINARIES_DIR}
 
 wget https://github.com/Toporin/Seedkeeper-Applet/releases/download/v0.2-0.1/SeedKeeper-v0.2-0.1.cap
 mv SeedKeeper-v0.2-0.1.cap ${BINARIES_DIR}
@@ -144,10 +144,10 @@ cp ${BINARIES_DIR}/diy-tools.squashfs boot/diy-tools.squashfs
 
 # Copy Seedsigner Images
 mkdir -p boot/microsd-images microsd-images
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi0.img microsd-images/seedsigner_os.0.8.5.pi0.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi02w.img microsd-images/seedsigner_os.0.8.5.pi02w.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi2.img microsd-images/seedsigner_os.0.8.5.pi2.img
-cp ${BINARIES_DIR}/seedsigner_os.0.8.5.pi4.img microsd-images/seedsigner_os.0.8.5.pi4.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi0.img microsd-images/seedsigner_os.0.8.6.pi0.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi02w.img microsd-images/seedsigner_os.0.8.6.pi02w.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi2.img microsd-images/seedsigner_os.0.8.6.pi2.img
+cp ${BINARIES_DIR}/seedsigner_os.0.8.6.pi4.img microsd-images/seedsigner_os.0.8.6.pi4.img
 
 # Copy Pre-Compiled CAP files
 mkdir -p boot/javacard-cap javacard-cap


### PR DESCRIPTION
## Summary
- update all image download links to SeedSigner `0.8.6`
- update genimage configs with the new image version
- refresh documentation examples for `0.8.6`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6882e9ced7888322b7b583315a0d95d1