### PR TITLE
Fix shamir-mnemonic missing wordlist

### DIFF
--- a/opt/external-packages/python-shamir-mnemonic/0001-Include-wordlist.patch
+++ b/opt/external-packages/python-shamir-mnemonic/0001-Include-wordlist.patch
@@ -1,0 +1,23 @@
+From 1234567890abcdef1234567890abcdef12345678 Mon Sep 17 00:00:00 2001
+From: Codex <>
+Date: Thu, 24 Jul 2025 00:00:00 +0000
+Subject: [PATCH] Include wordlist data for setuptools build
+
+Ensure wordlist.txt is installed when the package is built with
+setuptools by specifying package-data in pyproject.toml.
+---
+ pyproject.toml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@
+ [tool.poetry.scripts]
+ shamir = "shamir_mnemonic.cli:cli"
++
++[tool.setuptools.package-data]
++shamir_mnemonic = ["wordlist.txt"]
+
+ [build-system]
+ requires = ["poetry-core"]
+ build-backend = "poetry.core.masonry.api"

--- a/opt/external-packages/python-shamir-mnemonic/0001-Include-wordlist.patch
+++ b/opt/external-packages/python-shamir-mnemonic/0001-Include-wordlist.patch
@@ -9,16 +9,15 @@ Ensure wordlist.txt is packaged when building with setuptools.
  1 file changed, 3 insertions(+)
 
 diff --git a/pyproject.toml b/pyproject.toml
-index 6d30b74..94394bc 100644
+index 6d30b74..1d535ad 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -25,6 +25,9 @@
+@@ -25,6 +25,8 @@
  [tool.poetry.scripts]
  shamir = "shamir_mnemonic.cli:cli"
 +[tool.setuptools.package-data]
 +shamir_mnemonic = ["wordlist.txt"]
-+
+ 
  [build-system]
  requires = ["poetry-core"]
  build-backend = "poetry.core.masonry.api"
-

--- a/opt/external-packages/python-shamir-mnemonic/0001-Include-wordlist.patch
+++ b/opt/external-packages/python-shamir-mnemonic/0001-Include-wordlist.patch
@@ -1,23 +1,24 @@
-From 1234567890abcdef1234567890abcdef12345678 Mon Sep 17 00:00:00 2001
+From 9e0294f3a3012345678901234567890123456789 Mon Sep 17 00:00:00 2001
 From: Codex <>
 Date: Thu, 24 Jul 2025 00:00:00 +0000
-Subject: [PATCH] Include wordlist data for setuptools build
+Subject: [PATCH] Include wordlist.txt in installed package
 
-Ensure wordlist.txt is installed when the package is built with
-setuptools by specifying package-data in pyproject.toml.
+Ensure wordlist.txt is packaged when building with setuptools.
 ---
  pyproject.toml | 3 +++
  1 file changed, 3 insertions(+)
 
+diff --git a/pyproject.toml b/pyproject.toml
+index 6d30b74..94394bc 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@
+@@ -25,6 +25,9 @@
  [tool.poetry.scripts]
  shamir = "shamir_mnemonic.cli:cli"
-+
 +[tool.setuptools.package-data]
 +shamir_mnemonic = ["wordlist.txt"]
-
++
  [build-system]
  requires = ["poetry-core"]
  build-backend = "poetry.core.masonry.api"
+


### PR DESCRIPTION
## Summary
- add patch so setuptools installs wordlist.txt for shamir-mnemonic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a2bf4f8fc83228a273c9792800a96