### PR TITLE
Add wordlist fetch for Shamir mnemonic

### DIFF
--- a/opt/pi0-smartcard-dev/board/post-build.sh
+++ b/opt/pi0-smartcard-dev/board/post-build.sh
@@ -45,6 +45,9 @@ rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
 
+# Workaround for building Shamir-mnemonic with setuptools instead of Poetry
+# TODO: remove once Buildroot supports Poetry natively.
+wget -q -O ${TARGET_DIR}/usr/lib/python3.10/site-packages/shamir_mnemonic/wordlist.txt https://raw.githubusercontent.com/trezor/python-shamir-mnemonic/master/shamir_mnemonic/wordlist.txt
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 

--- a/opt/pi0-smartcard/board/post-build.sh
+++ b/opt/pi0-smartcard/board/post-build.sh
@@ -38,6 +38,9 @@ rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtledemo
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/unittest
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/ensurepip
+# Workaround for building Shamir-mnemonic with setuptools instead of Poetry
+# TODO: remove once Buildroot supports Poetry natively.
+wget -q -O ${TARGET_DIR}/usr/lib/python3.10/site-packages/shamir_mnemonic/wordlist.txt https://raw.githubusercontent.com/trezor/python-shamir-mnemonic/master/shamir_mnemonic/wordlist.txt
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions

--- a/opt/pi02w-smartcard-dev/board/post-build.sh
+++ b/opt/pi02w-smartcard-dev/board/post-build.sh
@@ -45,6 +45,9 @@ rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
 
+# Workaround for building Shamir-mnemonic with setuptools instead of Poetry
+# TODO: remove once Buildroot supports Poetry natively.
+wget -q -O ${TARGET_DIR}/usr/lib/python3.10/site-packages/shamir_mnemonic/wordlist.txt https://raw.githubusercontent.com/trezor/python-shamir-mnemonic/master/shamir_mnemonic/wordlist.txt
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 

--- a/opt/pi02w-smartcard/board/post-build.sh
+++ b/opt/pi02w-smartcard/board/post-build.sh
@@ -38,6 +38,9 @@ rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtledemo
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/unittest
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/ensurepip
+# Workaround for building Shamir-mnemonic with setuptools instead of Poetry
+# TODO: remove once Buildroot supports Poetry natively.
+wget -q -O ${TARGET_DIR}/usr/lib/python3.10/site-packages/shamir_mnemonic/wordlist.txt https://raw.githubusercontent.com/trezor/python-shamir-mnemonic/master/shamir_mnemonic/wordlist.txt
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions

--- a/opt/pi2-smartcard-dev/board/post-build.sh
+++ b/opt/pi2-smartcard-dev/board/post-build.sh
@@ -45,6 +45,9 @@ rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
 
+# Workaround for building Shamir-mnemonic with setuptools instead of Poetry
+# TODO: remove once Buildroot supports Poetry natively.
+wget -q -O ${TARGET_DIR}/usr/lib/python3.10/site-packages/shamir_mnemonic/wordlist.txt https://raw.githubusercontent.com/trezor/python-shamir-mnemonic/master/shamir_mnemonic/wordlist.txt
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 

--- a/opt/pi2-smartcard/board/post-build.sh
+++ b/opt/pi2-smartcard/board/post-build.sh
@@ -38,6 +38,9 @@ rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtledemo
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/unittest
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/ensurepip
+# Workaround for building Shamir-mnemonic with setuptools instead of Poetry
+# TODO: remove once Buildroot supports Poetry natively.
+wget -q -O ${TARGET_DIR}/usr/lib/python3.10/site-packages/shamir_mnemonic/wordlist.txt https://raw.githubusercontent.com/trezor/python-shamir-mnemonic/master/shamir_mnemonic/wordlist.txt
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions

--- a/opt/pi4-smartcard-dev/board/post-build.sh
+++ b/opt/pi4-smartcard-dev/board/post-build.sh
@@ -47,6 +47,9 @@ rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtledemo
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/unittest
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/ensurepip
+# Workaround for building Shamir-mnemonic with setuptools instead of Poetry
+# TODO: remove once Buildroot supports Poetry natively.
+wget -q -O ${TARGET_DIR}/usr/lib/python3.10/site-packages/shamir_mnemonic/wordlist.txt https://raw.githubusercontent.com/trezor/python-shamir-mnemonic/master/shamir_mnemonic/wordlist.txt
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions

--- a/opt/pi4-smartcard/board/post-build.sh
+++ b/opt/pi4-smartcard/board/post-build.sh
@@ -38,6 +38,9 @@ rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtledemo
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/unittest
 rm -rf ${TARGET_DIR}/usr/lib/python3.10/ensurepip
+# Workaround for building Shamir-mnemonic with setuptools instead of Poetry
+# TODO: remove once Buildroot supports Poetry natively.
+wget -q -O ${TARGET_DIR}/usr/lib/python3.10/site-packages/shamir_mnemonic/wordlist.txt https://raw.githubusercontent.com/trezor/python-shamir-mnemonic/master/shamir_mnemonic/wordlist.txt
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions


### PR DESCRIPTION
## Summary
- update all smartcard build profiles to fetch the Shamir wordlist during build
- clarify workaround and add TODO for future Buildroot versions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a7d69d0048322ace67bda9210f4f2