### PR TITLE
Update python-shamir-mnemonic source

### DIFF
--- a/opt/external-packages/python-shamir-mnemonic/Config.in
+++ b/opt/external-packages/python-shamir-mnemonic/Config.in
@@ -3,4 +3,4 @@ config BR2_PACKAGE_PYTHON_SHAMIR_MNEMONIC
         help
           SLIP-0039 Shamir's Secret-Sharing for mnemonic phrases
 
-          https://github.com/trezor/python-shamir-mnemonic
+          https://github.com/3rdIteration/python-shamir-mnemonic

--- a/opt/external-packages/python-shamir-mnemonic/python-shamir-mnemonic.hash
+++ b/opt/external-packages/python-shamir-mnemonic/python-shamir-mnemonic.hash
@@ -1,2 +1,2 @@
-# md5, sha256 from https://github.com/trezor/python-shamir-mnemonic
-sha256 6994ab80ace0f49c3434a86c06c04b2342066ae183b4fe4a5c34d1ef85e7eced  python-shamir-mnemonic-0.3.0.tar.gz
+# md5, sha256 from https://github.com/3rdIteration/python-shamir-mnemonic
+sha256 6fdcfb8d4380a8427ba28805eea63511a793fdfc6732d5c44d0f91a6b273445b  python-shamir-mnemonic-0.3-setuptools.tar.gz

--- a/opt/external-packages/python-shamir-mnemonic/python-shamir-mnemonic.mk
+++ b/opt/external-packages/python-shamir-mnemonic/python-shamir-mnemonic.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-PYTHON_SHAMIR_MNEMONIC_VERSION = 0.3.0
-PYTHON_SHAMIR_MNEMONIC_SITE = $(call github,trezor,python-shamir-mnemonic,v$(PYTHON_SHAMIR_MNEMONIC_VERSION))
+PYTHON_SHAMIR_MNEMONIC_VERSION = 0.3-setuptools
+PYTHON_SHAMIR_MNEMONIC_SITE = $(call github,3rdIteration,python-shamir-mnemonic,$(PYTHON_SHAMIR_MNEMONIC_VERSION))
 PYTHON_SHAMIR_MNEMONIC_SETUP_TYPE = setuptools
 PYTHON_SHAMIR_MNEMONIC_LICENSE = MIT
 


### PR DESCRIPTION
## Summary
- point python-shamir-mnemonic package to 3rdIteration repo
- bump version to `0.3-setuptools`
- update source hashes and docs

## Testing
- `sha256sum python-shamir-mnemonic-0.3-setuptools.tar.gz`


------
https://chatgpt.com/codex/tasks/task_e_688ab3fb6f608322856ecc7d9a6d51cb