### PR TITLE
Enable RIPEMD160 hashing for Satochip workflows

### DIFF
--- a/opt/rootfs-overlay/etc/ssl/openssl.cnf
+++ b/opt/rootfs-overlay/etc/ssl/openssl.cnf
@@ -1,0 +1,14 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1

--- a/opt/rootfs-overlay/start.sh
+++ b/opt/rootfs-overlay/start.sh
@@ -3,10 +3,13 @@
 # Set the date to release so that GPG can work
 /bin/date -s "2025-02-28 12:00"
 
-# Import the bundle of keys 
+# Import the bundle of keys
 /usr/bin/gpg --import /gpg/*.asc
 
 cd /opt/src/
+
+# Ensure OpenSSL loads the legacy provider so RIPEMD160 is available
+export OPENSSL_CONF=/etc/ssl/openssl.cnf
 
 #/usr/bin/python3 main.py >> /dev/kmsg 2>&1 &  # version that writes output to dmesg
 /usr/bin/python3 main.py &


### PR DESCRIPTION
## Summary
- load OpenSSL legacy provider at boot so RIPEMD160 hashes are supported
- include an OpenSSL configuration enabling the legacy provider

## Testing
- `OPENSSL_CONF=opt/rootfs-overlay/etc/ssl/openssl.cnf python - <<'PY'\nimport hashlib\nprint('ripemd160' in hashlib.algorithms_available)\nPY`


------
https://chatgpt.com/codex/tasks/task_e_688fcff848448322b1736d2c3c683634