### PR TITLE
Start Python app before asynchronous GPG key import

### DIFF
--- a/opt/rootfs-overlay-dev/start.sh
+++ b/opt/rootfs-overlay-dev/start.sh
@@ -3,9 +3,6 @@
 # Set the date to release so that GPG can work
 /bin/date -s "2025-02-28 12:00"
 
-# Import the bundle of keys 
-/usr/bin/gpg --import /gpg/*.asc
-
 if [ -d /mnt/microsd/seedsigner-dev ]; then
     echo "Running SeedSigner from external MicroSD source"
     cd /mnt/microsd/seedsigner-dev
@@ -17,3 +14,6 @@ fi
 
 #/usr/bin/python3 main.py >> /dev/kmsg 2>&1 &  # version that writes output to dmesg
 /usr/bin/python3 main.py &
+
+# Import the bundle of keys a few seconds after the app starts
+(sleep 5 && /usr/bin/gpg --import /gpg/*.asc) &

--- a/opt/rootfs-overlay/start.sh
+++ b/opt/rootfs-overlay/start.sh
@@ -3,10 +3,10 @@
 # Set the date to release so that GPG can work
 /bin/date -s "2025-02-28 12:00"
 
-# Import the bundle of keys 
-/usr/bin/gpg --import /gpg/*.asc
-
 cd /opt/src/
 
 #/usr/bin/python3 main.py >> /dev/kmsg 2>&1 &  # version that writes output to dmesg
 /usr/bin/python3 main.py &
+
+# Import the bundle of keys a few seconds after the app starts
+(sleep 5 && /usr/bin/gpg --import /gpg/*.asc) &


### PR DESCRIPTION
## Summary
- Launch SeedSigner Python app immediately on startup
- Import bundled GPG keys asynchronously after a 5s delay to avoid blocking app start

## Testing
- `sh -n opt/rootfs-overlay/start.sh`
- `sh -n opt/rootfs-overlay-dev/start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68978f5915b483228315408ba2a458dd