### PR TITLE
Update pysatochip package to 0.5-alpha

### DIFF
--- a/opt/external-packages/python-pysatochip/python-pysatochip.hash
+++ b/opt/external-packages/python-pysatochip/python-pysatochip.hash
@@ -1,2 +1,2 @@
 # md5, sha256 from https://github.com/3rdIteration/pysatochip/releases
-sha256 fe931876a10aa95a9d65a34959aba4a971703359eb0b4641c7bdc4121ef01707  python-pysatochip-0.4-alpha.tar.gz
+sha256 49714d0dce76ae0a5fa70f256835a11c56aff5cd912be577443ab6240cdb9687  python-pysatochip-0.5-alpha.tar.gz

--- a/opt/external-packages/python-pysatochip/python-pysatochip.mk
+++ b/opt/external-packages/python-pysatochip/python-pysatochip.mk
@@ -4,7 +4,7 @@
  #
  ################################################################################
 
- PYTHON_PYSATOCHIP_VERSION = 0.4-alpha
+ PYTHON_PYSATOCHIP_VERSION = 0.5-alpha
  PYTHON_PYSATOCHIP_SITE = $(call github,3rdIteration,pysatochip,$(PYTHON_PYSATOCHIP_VERSION))
  PYTHON_PYSATOCHIP_SETUP_TYPE = setuptools
  PYTHON_PYSATOCHIP_LICENSE = LGPL


### PR DESCRIPTION
## Summary
- update pysatochip to latest 0.5-alpha release
- refresh source archive hash

## Testing
- `echo "49714d0dce76ae0a5fa70f256835a11c56aff5cd912be577443ab6240cdb9687  /tmp/python-pysatochip-0.5-alpha.tar.gz" | sha256sum -c`


------
https://chatgpt.com/codex/tasks/task_e_68a1d40aa10c8322a394155a70b5854e