### PR TITLE
Log dev main output to MicroSD

### DIFF
--- a/opt/rootfs-overlay-dev/start.sh
+++ b/opt/rootfs-overlay-dev/start.sh
@@ -5,15 +5,21 @@
 
 if [ -d /mnt/microsd/seedsigner-dev ]; then
     echo "Running SeedSigner from external MicroSD source"
-    cd /mnt/microsd/seedsigner-dev
+    cd /mnt/microsd/seedsigner-dev || exit
     /usr/bin/python3 /usr/bin/microsd_notice.py || true
 else
     echo "Running SeedSigner from embedded source"
-    cd /opt/src/
+    cd /opt/src/ || exit
 fi
 
 #/usr/bin/python3 main.py >> /dev/kmsg 2>&1 &  # version that writes output to dmesg
-/usr/bin/python3 main.py &
+
+LOG_FILE="/mnt/microsd/main.log"
+if [ -d /mnt/microsd ]; then
+    /usr/bin/python3 main.py >> "${LOG_FILE}" 2>&1 &
+else
+    /usr/bin/python3 main.py &
+fi
 
 # Import the bundle of keys a few seconds after the app starts
 (sleep 5 && /usr/bin/gpg --import /gpg/*.asc) &


### PR DESCRIPTION
## Summary
- Append main.py output to /mnt/microsd/main.log when running dev images
- Fail fast on missing directories in start script

## Testing
- `shellcheck opt/rootfs-overlay-dev/start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a49694f89083229399bd3841006b59