### PR TITLE
Wait for MicroSD mount before launching dev build

### DIFF
--- a/opt/rootfs-overlay-dev/start.sh
+++ b/opt/rootfs-overlay-dev/start.sh
@@ -3,16 +3,25 @@
 # Set the date to release so that GPG can work
 /bin/date -s "2025-02-28 12:00"
 
-# Wait for the external MicroSD to be mounted before checking for a dev build.
-MICROSD_DEV_DIR="/mnt/microsd/seedsigner-dev"
+# Wait for the external MicroSD to mount before checking for a dev build.
+MICROSD_MOUNTPOINT="/mnt/microsd"
+MICROSD_DEV_DIR="$MICROSD_MOUNTPOINT/seedsigner-dev"
 MAX_WAIT=10
 COUNT=0
-while [ $COUNT -lt $MAX_WAIT ] && [ ! -d "$MICROSD_DEV_DIR" ]; do
+WAIT_MSG="Waiting for external MicroSD to mount..."
+
+echo "$WAIT_MSG"
+/usr/bin/python3 /usr/bin/microsd_notice.py --message "$WAIT_MSG" --duration "$MAX_WAIT" &
+NOTICE_PID=$!
+
+while [ $COUNT -lt $MAX_WAIT ] && ! mountpoint -q "$MICROSD_MOUNTPOINT"; do
     COUNT=$((COUNT + 1))
     sleep 1
 done
 
-if [ -d "$MICROSD_DEV_DIR" ]; then
+kill "$NOTICE_PID" 2>/dev/null
+
+if mountpoint -q "$MICROSD_MOUNTPOINT" && [ -d "$MICROSD_DEV_DIR" ]; then
     echo "Running SeedSigner from external MicroSD source"
     cd "$MICROSD_DEV_DIR" || exit 1
     /usr/bin/python3 /usr/bin/microsd_notice.py || true

--- a/opt/rootfs-overlay-dev/start.sh
+++ b/opt/rootfs-overlay-dev/start.sh
@@ -3,13 +3,22 @@
 # Set the date to release so that GPG can work
 /bin/date -s "2025-02-28 12:00"
 
-if [ -d /mnt/microsd/seedsigner-dev ]; then
+# Wait for the external MicroSD to be mounted before checking for a dev build.
+MICROSD_DEV_DIR="/mnt/microsd/seedsigner-dev"
+MAX_WAIT=10
+COUNT=0
+while [ $COUNT -lt $MAX_WAIT ] && [ ! -d "$MICROSD_DEV_DIR" ]; do
+    COUNT=$((COUNT + 1))
+    sleep 1
+done
+
+if [ -d "$MICROSD_DEV_DIR" ]; then
     echo "Running SeedSigner from external MicroSD source"
-    cd /mnt/microsd/seedsigner-dev
+    cd "$MICROSD_DEV_DIR" || exit 1
     /usr/bin/python3 /usr/bin/microsd_notice.py || true
 else
     echo "Running SeedSigner from embedded source"
-    cd /opt/src/
+    cd /opt/src/ || exit 1
 fi
 
 #/usr/bin/python3 main.py >> /dev/kmsg 2>&1 &  # version that writes output to dmesg

--- a/opt/rootfs-overlay-dev/usr/bin/microsd_notice.py
+++ b/opt/rootfs-overlay-dev/usr/bin/microsd_notice.py
@@ -1,30 +1,45 @@
 #!/usr/bin/env python3
-"""Display a short message indicating the dev build is loading from MicroSD.
+"""Display a short message on the SeedSigner screen."""
 
-This script is executed before launching the main SeedSigner application when a
-``seedsigner-dev`` folder is detected on the inserted MicroSD card.  It uses
-SeedSigner's own display modules and configuration to render a simple centered
-text message for five seconds and then clears the screen.
-"""
-
+import argparse
 import os
 import sys
 import time
 
-# SeedSigner isn't installed as a system module, so search common source paths
-# to pull in its display stack
-for path in ("/mnt/microsd/seedsigner-dev/", "/opt/src/"):
-    if os.path.isdir(path) and path not in sys.path:
-        sys.path.insert(0, path)
 
-try:
-    from PIL import ImageFont
-    from seedsigner.gui.renderer import Renderer
-except Exception:  # pragma: no cover - best effort in early boot
-    # Fallback: print to console if any graphics dependency is missing
-    print("Loading SeedSigner-Dev from MicroSD", flush=True)
-    time.sleep(5)
-else:
+def main() -> None:
+    """Render a message to both the console and SeedSigner display."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--message",
+        default="Loading SeedSigner-Dev from MicroSD",
+        help="Text to display",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=5,
+        help="Seconds to show the message",
+    )
+    args = parser.parse_args()
+
+    # Always echo the message to the console for debugging visibility
+    print(args.message, flush=True)
+
+    # SeedSigner isn't installed as a system module, so search common source paths
+    # to pull in its display stack
+    for path in ("/mnt/microsd/seedsigner-dev/", "/opt/src/"):
+        if os.path.isdir(path) and path not in sys.path:
+            sys.path.insert(0, path)
+
+    try:
+        from PIL import ImageFont
+        from seedsigner.gui.renderer import Renderer
+    except Exception:  # pragma: no cover - best effort in early boot
+        time.sleep(args.duration)
+        return
+
     try:
         Renderer.configure_instance()
         renderer = Renderer.get_instance()
@@ -36,14 +51,16 @@ else:
             )
         except Exception:  # pragma: no cover - font not found
             font = ImageFont.load_default()
-        message = "Loading SeedSigner-Dev from MicroSD"
-        width, height = renderer.draw.textsize(message, font=font)
+        width, height = renderer.draw.textsize(args.message, font=font)
         x = (renderer.canvas_width - width) // 2
         y = (renderer.canvas_height - height) // 2
-        renderer.draw.text((x, y), message, font=font, fill=(255, 255, 255))
+        renderer.draw.text((x, y), args.message, font=font, fill=(255, 255, 255))
         renderer.show_image()
-        time.sleep(5)
+        time.sleep(args.duration)
         renderer.display_blank_screen()
-    except Exception:
-        print("Loading SeedSigner-Dev from MicroSD", flush=True)
-        time.sleep(5)
+    except Exception:  # pragma: no cover - display failure
+        time.sleep(args.duration)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add retry loop in dev start script so external microSD is mounted before launching
- ensure `cd` failures abort script for clarity

## Testing
- `shellcheck opt/rootfs-overlay-dev/start.sh`
- `sh -n opt/rootfs-overlay-dev/start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a770d2948c8322a128936a46283aac