### PR TITLE
Update pyscard to 2.3.0

### DIFF
--- a/opt/external-packages/python-pyscard/python-pyscard.hash
+++ b/opt/external-packages/python-pyscard/python-pyscard.hash
@@ -1,2 +1,2 @@
 # md5, sha256 from https://github.com/LudovicRousseau/pyscard/releases
-sha256 969987f0d7fa2d5ab9e1df06f958e174bbbcce884fa75fabbb8a8a6bdd3bbdf0  python-pyscard-2.0.7.tar.gz
+sha256 526477601280795d3d6ea1a66fe5a6528a073fa08bc14a60c179b49b0cefd0d4  python-pyscard-2.3.0.tar.gz

--- a/opt/external-packages/python-pyscard/python-pyscard.mk
+++ b/opt/external-packages/python-pyscard/python-pyscard.mk
@@ -4,7 +4,7 @@
  #
  ################################################################################
 
- PYTHON_PYSCARD_VERSION = 2.0.7
+PYTHON_PYSCARD_VERSION = 2.3.0
  PYTHON_PYSCARD_SITE = $(call github,LudovicRousseau,pyscard,$(PYTHON_PYSCARD_VERSION))
  PYTHON_PYSCARD_SETUP_TYPE = setuptools
  PYTHON_PYSCARD_LICENSE = LGPL


### PR DESCRIPTION
## Summary
- bump python-pyscard Buildroot package to version 2.3.0
- update corresponding source archive hash

## Testing
- `make -C opt/buildroot help` *(fails: No rule to make target 'help')*
- `make -C opt/buildroot list-defconfigs` *(fails: No rule to make target 'list-defconfigs')*

------
https://chatgpt.com/codex/tasks/task_e_68a8d535431883229c020c316d71688c