### PR TITLE
Use official SmartPGP applets

### DIFF
--- a/opt/pi0-smartcard-dev/board/genimage-rpi-seedsigner.cfg
+++ b/opt/pi0-smartcard-dev/board/genimage-rpi-seedsigner.cfg
@@ -51,9 +51,13 @@ image boot.vfat {
 		image = "vivokey-otp.cap"
 	}
 
-		file javacard-cap/SmartPGPApplet-default.cap {
-		image = "SmartPGPApplet-default.cap"
-	}
+                file javacard-cap/SmartPGP-RSA2048.cap {
+                image = "SmartPGP-RSA2048.cap"
+        }
+
+                file javacard-cap/SmartPGP-RSA4096.cap {
+                image = "SmartPGP-RSA4096.cap"
+        }
 	
     label = "SEEDSIGNDEV"
   }

--- a/opt/pi0-smartcard-dev/board/post-image-seedsigner.sh
+++ b/opt/pi0-smartcard-dev/board/post-image-seedsigner.sh
@@ -84,8 +84,11 @@ mv MemoryCardApplet.cap ${BINARIES_DIR}
 wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/vivokey-otp.cap
 mv vivokey-otp.cap ${BINARIES_DIR}
 
-wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/SmartPGPApplet-default.cap
-mv SmartPGPApplet-default.cap ${BINARIES_DIR}
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap ${BINARIES_DIR}/SmartPGP-RSA2048.cap
+
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap ${BINARIES_DIR}/SmartPGP-RSA4096.cap
 
 rm -R -f ./tmp/
 

--- a/opt/pi0-smartcard/board/post-image-seedsigner.sh
+++ b/opt/pi0-smartcard/board/post-image-seedsigner.sh
@@ -84,8 +84,11 @@ mv MemoryCardApplet.cap ${BINARIES_DIR}
 wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/vivokey-otp.cap
 mv vivokey-otp.cap ${BINARIES_DIR}
 
-wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/SmartPGPApplet-default.cap
-mv SmartPGPApplet-default.cap ${BINARIES_DIR}
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap ${BINARIES_DIR}/SmartPGP-RSA2048.cap
+
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap ${BINARIES_DIR}/SmartPGP-RSA4096.cap
 
 rm -R -f ./tmp/
 
@@ -156,7 +159,8 @@ cp ${BINARIES_DIR}/SatoChip-0.12-05.cap javacard-cap/SatoChip-0.12-official.cap
 cp ${BINARIES_DIR}/Satodime-0.1-0.2.cap javacard-cap/SatoDime-0.1.2-official.cap
 cp ${BINARIES_DIR}/MemoryCardApplet.cap javacard-cap/SpecterDIY.cap
 cp ${BINARIES_DIR}/vivokey-otp.cap javacard-cap/vivokey-otp.cap
-cp ${BINARIES_DIR}/SmartPGPApplet-default.cap javacard-cap/SmartPGPApplet-default.cap
+cp ${BINARIES_DIR}/SmartPGP-RSA2048.cap javacard-cap/SmartPGP-RSA2048.cap
+cp ${BINARIES_DIR}/SmartPGP-RSA4096.cap javacard-cap/SmartPGP-RSA4096.cap
 
 chmod 0755 `find boot overlays microsd-images javacard-cap`
 touch -d "${disk_timestamp}" `find boot overlays microsd-images javacard-cap`

--- a/opt/pi02w-smartcard-dev/board/genimage-rpi-seedsigner.cfg
+++ b/opt/pi02w-smartcard-dev/board/genimage-rpi-seedsigner.cfg
@@ -51,9 +51,13 @@ image boot.vfat {
 		image = "vivokey-otp.cap"
 	}
 
-		file javacard-cap/SmartPGPApplet-default.cap {
-		image = "SmartPGPApplet-default.cap"
-	}
+                file javacard-cap/SmartPGP-RSA2048.cap {
+                image = "SmartPGP-RSA2048.cap"
+        }
+
+                file javacard-cap/SmartPGP-RSA4096.cap {
+                image = "SmartPGP-RSA4096.cap"
+        }
 	
     label = "SEEDSIGNDEV"
   }

--- a/opt/pi02w-smartcard-dev/board/post-image-seedsigner.sh
+++ b/opt/pi02w-smartcard-dev/board/post-image-seedsigner.sh
@@ -84,8 +84,11 @@ mv MemoryCardApplet.cap ${BINARIES_DIR}
 wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/vivokey-otp.cap
 mv vivokey-otp.cap ${BINARIES_DIR}
 
-wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/SmartPGPApplet-default.cap
-mv SmartPGPApplet-default.cap ${BINARIES_DIR}
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap ${BINARIES_DIR}/SmartPGP-RSA2048.cap
+
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap ${BINARIES_DIR}/SmartPGP-RSA4096.cap
 
 rm -R -f ./tmp/
 

--- a/opt/pi02w-smartcard/board/post-image-seedsigner.sh
+++ b/opt/pi02w-smartcard/board/post-image-seedsigner.sh
@@ -84,8 +84,11 @@ mv MemoryCardApplet.cap ${BINARIES_DIR}
 wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/vivokey-otp.cap
 mv vivokey-otp.cap ${BINARIES_DIR}
 
-wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/SmartPGPApplet-default.cap
-mv SmartPGPApplet-default.cap ${BINARIES_DIR}
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap ${BINARIES_DIR}/SmartPGP-RSA2048.cap
+
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap ${BINARIES_DIR}/SmartPGP-RSA4096.cap
 
 rm -R -f ./tmp/
 
@@ -156,7 +159,8 @@ cp ${BINARIES_DIR}/SatoChip-0.12-05.cap javacard-cap/SatoChip-0.12-official.cap
 cp ${BINARIES_DIR}/Satodime-0.1-0.2.cap javacard-cap/SatoDime-0.1.2-official.cap
 cp ${BINARIES_DIR}/MemoryCardApplet.cap javacard-cap/SpecterDIY.cap
 cp ${BINARIES_DIR}/vivokey-otp.cap javacard-cap/vivokey-otp.cap
-cp ${BINARIES_DIR}/SmartPGPApplet-default.cap javacard-cap/SmartPGPApplet-default.cap
+cp ${BINARIES_DIR}/SmartPGP-RSA2048.cap javacard-cap/SmartPGP-RSA2048.cap
+cp ${BINARIES_DIR}/SmartPGP-RSA4096.cap javacard-cap/SmartPGP-RSA4096.cap
 
 chmod 0755 `find boot overlays microsd-images javacard-cap`
 touch -d "${disk_timestamp}" `find boot overlays microsd-images javacard-cap`

--- a/opt/pi2-smartcard-dev/board/genimage-rpi-seedsigner.cfg
+++ b/opt/pi2-smartcard-dev/board/genimage-rpi-seedsigner.cfg
@@ -48,9 +48,13 @@ image boot.vfat {
 		image = "vivokey-otp.cap"
 	}
 
-		file javacard-cap/SmartPGPApplet-default.cap {
-		image = "SmartPGPApplet-default.cap"
-	}
+                file javacard-cap/SmartPGP-RSA2048.cap {
+                image = "SmartPGP-RSA2048.cap"
+        }
+
+                file javacard-cap/SmartPGP-RSA4096.cap {
+                image = "SmartPGP-RSA4096.cap"
+        }
 	
     label = "SEEDSIGNDEV"
   }

--- a/opt/pi2-smartcard-dev/board/post-image-seedsigner.sh
+++ b/opt/pi2-smartcard-dev/board/post-image-seedsigner.sh
@@ -84,8 +84,11 @@ mv MemoryCardApplet.cap ${BINARIES_DIR}
 wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/vivokey-otp.cap
 mv vivokey-otp.cap ${BINARIES_DIR}
 
-wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/SmartPGPApplet-default.cap
-mv SmartPGPApplet-default.cap ${BINARIES_DIR}
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap ${BINARIES_DIR}/SmartPGP-RSA2048.cap
+
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap ${BINARIES_DIR}/SmartPGP-RSA4096.cap
 
 rm -R -f ./tmp/
 

--- a/opt/pi2-smartcard/board/post-image-seedsigner.sh
+++ b/opt/pi2-smartcard/board/post-image-seedsigner.sh
@@ -84,8 +84,11 @@ mv MemoryCardApplet.cap ${BINARIES_DIR}
 wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/vivokey-otp.cap
 mv vivokey-otp.cap ${BINARIES_DIR}
 
-wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/SmartPGPApplet-default.cap
-mv SmartPGPApplet-default.cap ${BINARIES_DIR}
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap ${BINARIES_DIR}/SmartPGP-RSA2048.cap
+
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap ${BINARIES_DIR}/SmartPGP-RSA4096.cap
 
 rm -R -f ./tmp/
 
@@ -156,7 +159,8 @@ cp ${BINARIES_DIR}/SatoChip-0.12-05.cap javacard-cap/SatoChip-0.12-official.cap
 cp ${BINARIES_DIR}/Satodime-0.1-0.2.cap javacard-cap/SatoDime-0.1.2-official.cap
 cp ${BINARIES_DIR}/MemoryCardApplet.cap javacard-cap/SpecterDIY.cap
 cp ${BINARIES_DIR}/vivokey-otp.cap javacard-cap/vivokey-otp.cap
-cp ${BINARIES_DIR}/SmartPGPApplet-default.cap javacard-cap/SmartPGPApplet-default.cap
+cp ${BINARIES_DIR}/SmartPGP-RSA2048.cap javacard-cap/SmartPGP-RSA2048.cap
+cp ${BINARIES_DIR}/SmartPGP-RSA4096.cap javacard-cap/SmartPGP-RSA4096.cap
 
 chmod 0755 `find boot overlays microsd-images javacard-cap`
 touch -d "${disk_timestamp}" `find boot overlays microsd-images javacard-cap`

--- a/opt/pi4-smartcard-dev/board/genimage-rpi-seedsigner.cfg
+++ b/opt/pi4-smartcard-dev/board/genimage-rpi-seedsigner.cfg
@@ -48,9 +48,13 @@ image boot.vfat {
 		image = "vivokey-otp.cap"
 	}
 
-		file javacard-cap/SmartPGPApplet-default.cap {
-		image = "SmartPGPApplet-default.cap"
-	}
+                file javacard-cap/SmartPGP-RSA2048.cap {
+                image = "SmartPGP-RSA2048.cap"
+        }
+
+                file javacard-cap/SmartPGP-RSA4096.cap {
+                image = "SmartPGP-RSA4096.cap"
+        }
 	
     label = "SEEDSIGNDEV"
   }

--- a/opt/pi4-smartcard-dev/board/post-image-seedsigner.sh
+++ b/opt/pi4-smartcard-dev/board/post-image-seedsigner.sh
@@ -84,8 +84,11 @@ mv MemoryCardApplet.cap ${BINARIES_DIR}
 wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/vivokey-otp.cap
 mv vivokey-otp.cap ${BINARIES_DIR}
 
-wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/SmartPGPApplet-default.cap
-mv SmartPGPApplet-default.cap ${BINARIES_DIR}
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap ${BINARIES_DIR}/SmartPGP-RSA2048.cap
+
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap ${BINARIES_DIR}/SmartPGP-RSA4096.cap
 
 rm -R -f ./tmp/
 

--- a/opt/pi4-smartcard/board/post-image-seedsigner.sh
+++ b/opt/pi4-smartcard/board/post-image-seedsigner.sh
@@ -84,8 +84,11 @@ mv MemoryCardApplet.cap ${BINARIES_DIR}
 wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/vivokey-otp.cap
 mv vivokey-otp.cap ${BINARIES_DIR}
 
-wget https://github.com/DangerousThings/flexsecure-applets/releases/download/v0.18.9/SmartPGPApplet-default.cap
-mv SmartPGPApplet-default.cap ${BINARIES_DIR}
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_2048.cap ${BINARIES_DIR}/SmartPGP-RSA2048.cap
+
+wget https://github.com/github-af/SmartPGP/releases/download/v1.22.2-3.0.4/SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap
+mv SmartPGP-v1.22.2-jc304-rsa_up_to_4096.cap ${BINARIES_DIR}/SmartPGP-RSA4096.cap
 
 rm -R -f ./tmp/
 
@@ -156,7 +159,8 @@ cp ${BINARIES_DIR}/SatoChip-0.12-05.cap javacard-cap/SatoChip-0.12-official.cap
 cp ${BINARIES_DIR}/Satodime-0.1-0.2.cap javacard-cap/SatoDime-0.1.2-official.cap
 cp ${BINARIES_DIR}/MemoryCardApplet.cap javacard-cap/SpecterDIY.cap
 cp ${BINARIES_DIR}/vivokey-otp.cap javacard-cap/vivokey-otp.cap
-cp ${BINARIES_DIR}/SmartPGPApplet-default.cap javacard-cap/SmartPGPApplet-default.cap
+cp ${BINARIES_DIR}/SmartPGP-RSA2048.cap javacard-cap/SmartPGP-RSA2048.cap
+cp ${BINARIES_DIR}/SmartPGP-RSA4096.cap javacard-cap/SmartPGP-RSA4096.cap
 
 chmod 0755 `find boot overlays microsd-images javacard-cap`
 touch -d "${disk_timestamp}" `find boot overlays microsd-images javacard-cap`


### PR DESCRIPTION
## Summary
- Switch SmartPGP applet downloads to the official repository
- Add both RSA2048 and RSA4096 applets as SmartPGP-RSA2048 and SmartPGP-RSA4096
- Update build scripts and genimage configs to package new applets

## Testing
- `bash -n opt/pi0-smartcard-dev/board/post-image-seedsigner.sh opt/pi0-smartcard/board/post-image-seedsigner.sh opt/pi02w-smartcard-dev/board/post-image-seedsigner.sh opt/pi02w-smartcard/board/post-image-seedsigner.sh opt/pi2-smartcard-dev/board/post-image-seedsigner.sh opt/pi2-smartcard/board/post-image-seedsigner.sh opt/pi4-smartcard-dev/board/post-image-seedsigner.sh opt/pi4-smartcard/board/post-image-seedsigner.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b90395410083228ee5eb4ac96d99da