### PR TITLE
Add scdaemon config to disable CCID in rootfs overlay

### DIFF
--- a/opt/rootfs-overlay/root/.gnupg/scdaemon.conf
+++ b/opt/rootfs-overlay/root/.gnupg/scdaemon.conf
@@ -1,0 +1,1 @@
+disable-ccid


### PR DESCRIPTION
## Summary
- disable smart card reader CCID driver via scdaemon config in root's home for rootfs overlay

## Testing
- `./opt/build.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_68b9f93213488322be2e50cf7cd15095