### PR TITLE
Use generic pinentry for gpg-agent

### DIFF
--- a/opt/rootfs-overlay/root/.gnupg/gpg-agent.conf
+++ b/opt/rootfs-overlay/root/.gnupg/gpg-agent.conf
@@ -1,2 +1,2 @@
-pinentry-program /usr/bin/pinentry-ncurses
+pinentry-program /usr/bin/pinentry
 


### PR DESCRIPTION
## Summary
- configure gpg-agent to invoke `/usr/bin/pinentry` instead of `/usr/bin/pinentry-ncurses`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb2cbe89488322b4120f09fcde3a52