### PR TITLE
Update build scripts for Python 3.12

### DIFF
--- a/opt/pi0-dev/board/post-build.sh
+++ b/opt/pi0-dev/board/post-build.sh
@@ -17,10 +17,8 @@ console::respawn:-/bin/sh\
 tty1::respawn:-/bin/sh' ${TARGET_DIR}/etc/inittab
 fi
 
-# Adding symlink to support upgrade of buildroot python3.10 to python3.12
-ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3.10
+# Ensure python3 points to python3.12
 ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3
-ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3-3.10.10
 ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3
 
 # Clean up test files included with numpy

--- a/opt/pi0-smartcard-dev/board/post-build.sh
+++ b/opt/pi0-smartcard-dev/board/post-build.sh
@@ -26,67 +26,67 @@ rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
 # Clean up test files included with numpy
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/testing
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/linalg/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/typing/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/testing
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/linalg/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/typing/tests
 
 # Clean up files included in embit we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/embit/liquid
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/embit/liquid
 
 # Clean up tests/docs in other python included libs
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/pyzbar/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/qrcode/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/pyzbar/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/qrcode/tests
 
 # Clean up bigger python modules we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtle.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pydoc.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/doctest.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/mailbox.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtle.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pydoc.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/doctest.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/mailbox.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/zipfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/tarfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pickletools.pyc
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 
-rm -f ${TARGET_DIR}/usr/lib/python3.10/config-3.10-arm-linux-gnueabihf/Makefile
-rm -f ${TARGET_DIR}/usr/lib/python3.10/multiprocessing/connection.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/json/decoder.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/_string_helpers.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/ccompiler.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/command/build_py.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/misc_util.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/system_info.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/auxfuncs.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/crackfortran.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/f2py2e.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/_iotools.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/npyio.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/recfunctions.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/stride_tricks.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/traceback.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/config-3.12-arm-linux-gnueabihf/Makefile
+rm -f ${TARGET_DIR}/usr/lib/python3.12/multiprocessing/connection.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/json/decoder.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/_string_helpers.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/ccompiler.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/command/build_py.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/misc_util.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/system_info.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/auxfuncs.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/crackfortran.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/f2py2e.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/_iotools.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/npyio.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/recfunctions.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/stride_tricks.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/traceback.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
 
-find ${TARGET_DIR}/usr/lib/python3.10 -name '*.py' \
-	-not -path "*/python3.10/multiprocessing/connection.py" \
-	-not -path "*/python3.10/json/decoder.py" \
-	-not -path "*/python3.10/site-packages/numpy/core/_string_helpers.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/ccompiler.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/command/build_py.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/misc_util.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/system_info.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/auxfuncs.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/crackfortran.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/f2py2e.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/_iotools.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/npyio.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/recfunctions.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/stride_tricks.py" \
-	-not -path "*/python3.10/traceback.py" \
-	-not -path "*/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
+find ${TARGET_DIR}/usr/lib/python3.12 -name '*.py' \
+	-not -path "*/python3.12/multiprocessing/connection.py" \
+	-not -path "*/python3.12/json/decoder.py" \
+	-not -path "*/python3.12/site-packages/numpy/core/_string_helpers.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/ccompiler.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/command/build_py.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/misc_util.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/system_info.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/auxfuncs.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/crackfortran.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/f2py2e.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/_iotools.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/npyio.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/recfunctions.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/stride_tricks.py" \
+	-not -path "*/python3.12/traceback.py" \
+	-not -path "*/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
 	-print0 | \
 	xargs -0 --no-run-if-empty rm -f
 

--- a/opt/pi0-smartcard/board/post-build.sh
+++ b/opt/pi0-smartcard/board/post-build.sh
@@ -13,76 +13,76 @@ rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
 # Clean up test files included with numpy
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/testing
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/linalg/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/typing/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/testing
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/linalg/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/typing/tests
 
 # Clean up files included in embit we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/embit/liquid
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/embit/liquid
 
 # Clean up tests/docs in other python included libs
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/pyzbar/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/qrcode/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/pyzbar/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/qrcode/tests
 
 # Clean up bigger python modules we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtle.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pydoc.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/doctest.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/mailbox.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtledemo
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/unittest
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/ensurepip
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtle.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pydoc.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/doctest.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/mailbox.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/zipfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/tarfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pickletools.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtledemo
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/unittest
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/ensurepip
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 
-rm -f ${TARGET_DIR}/usr/lib/python3.10/config-3.10-arm-linux-gnueabihf/Makefile
-rm -f ${TARGET_DIR}/usr/lib/python3.10/multiprocessing/connection.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/json/decoder.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/_string_helpers.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/ccompiler.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/command/build_py.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/misc_util.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/system_info.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/auxfuncs.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/crackfortran.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/f2py2e.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/_iotools.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/npyio.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/recfunctions.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/stride_tricks.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/traceback.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/config-3.12-arm-linux-gnueabihf/Makefile
+rm -f ${TARGET_DIR}/usr/lib/python3.12/multiprocessing/connection.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/json/decoder.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/_string_helpers.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/ccompiler.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/command/build_py.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/misc_util.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/system_info.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/auxfuncs.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/crackfortran.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/f2py2e.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/_iotools.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/npyio.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/recfunctions.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/stride_tricks.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/traceback.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
 
-find ${TARGET_DIR}/usr/lib/python3.10 -name '*.py' \
-	-not -path "*/python3.10/multiprocessing/connection.py" \
-	-not -path "*/python3.10/json/decoder.py" \
-	-not -path "*/python3.10/site-packages/numpy/core/_string_helpers.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/ccompiler.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/command/build_py.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/misc_util.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/system_info.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/auxfuncs.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/crackfortran.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/f2py2e.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/_iotools.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/npyio.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/recfunctions.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/stride_tricks.py" \
-	-not -path "*/python3.10/traceback.py" \
-	-not -path "*/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
+find ${TARGET_DIR}/usr/lib/python3.12 -name '*.py' \
+	-not -path "*/python3.12/multiprocessing/connection.py" \
+	-not -path "*/python3.12/json/decoder.py" \
+	-not -path "*/python3.12/site-packages/numpy/core/_string_helpers.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/ccompiler.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/command/build_py.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/misc_util.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/system_info.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/auxfuncs.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/crackfortran.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/f2py2e.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/_iotools.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/npyio.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/recfunctions.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/stride_tricks.py" \
+	-not -path "*/python3.12/traceback.py" \
+	-not -path "*/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
 	-print0 | \
 	xargs -0 --no-run-if-empty rm -f
 
 find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -f
 
 # Add python byte code (aka __pycache__ directories) to increase boot and import module speed
-SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.10 \
-  "${BUILD_DIR}/python3-3.10.10/Lib/compileall.py" \
+SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
+  "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"

--- a/opt/pi0/board/post-build.sh
+++ b/opt/pi0/board/post-build.sh
@@ -12,10 +12,8 @@ rm -f ${TARGET_DIR}/etc/init.d/S20seedrng
 rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
-# Adding symlink to support upgrade of buildroot python3.10 to python3.12
-ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3.10
+# Ensure python3 points to python3.12
 ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3
-ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3-3.10.10
 ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3
 
 # Clean up test files included with numpy

--- a/opt/pi02w-dev/board/post-build.sh
+++ b/opt/pi02w-dev/board/post-build.sh
@@ -17,10 +17,8 @@ console::respawn:-/bin/sh\
 tty1::respawn:-/bin/sh' ${TARGET_DIR}/etc/inittab
 fi
 
-# Adding symlink to support upgrade of buildroot python3.10 to python3.12
-ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3.10
+# Ensure python3 points to python3.12
 ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3
-ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3-3.10.10
 ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3
 
 # Clean up test files included with numpy

--- a/opt/pi02w-smartcard-dev/board/post-build.sh
+++ b/opt/pi02w-smartcard-dev/board/post-build.sh
@@ -26,67 +26,67 @@ rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
 # Clean up test files included with numpy
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/testing
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/linalg/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/typing/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/testing
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/linalg/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/typing/tests
 
 # Clean up files included in embit we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/embit/liquid
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/embit/liquid
 
 # Clean up tests/docs in other python included libs
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/pyzbar/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/qrcode/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/pyzbar/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/qrcode/tests
 
 # Clean up bigger python modules we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtle.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pydoc.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/doctest.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/mailbox.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtle.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pydoc.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/doctest.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/mailbox.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/zipfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/tarfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pickletools.pyc
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 
-rm -f ${TARGET_DIR}/usr/lib/python3.10/config-3.10-arm-linux-gnueabihf/Makefile
-rm -f ${TARGET_DIR}/usr/lib/python3.10/multiprocessing/connection.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/json/decoder.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/_string_helpers.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/ccompiler.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/command/build_py.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/misc_util.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/system_info.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/auxfuncs.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/crackfortran.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/f2py2e.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/_iotools.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/npyio.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/recfunctions.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/stride_tricks.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/traceback.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/config-3.12-arm-linux-gnueabihf/Makefile
+rm -f ${TARGET_DIR}/usr/lib/python3.12/multiprocessing/connection.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/json/decoder.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/_string_helpers.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/ccompiler.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/command/build_py.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/misc_util.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/system_info.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/auxfuncs.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/crackfortran.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/f2py2e.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/_iotools.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/npyio.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/recfunctions.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/stride_tricks.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/traceback.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
 
-find ${TARGET_DIR}/usr/lib/python3.10 -name '*.py' \
-	-not -path "*/python3.10/multiprocessing/connection.py" \
-	-not -path "*/python3.10/json/decoder.py" \
-	-not -path "*/python3.10/site-packages/numpy/core/_string_helpers.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/ccompiler.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/command/build_py.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/misc_util.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/system_info.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/auxfuncs.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/crackfortran.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/f2py2e.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/_iotools.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/npyio.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/recfunctions.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/stride_tricks.py" \
-	-not -path "*/python3.10/traceback.py" \
-	-not -path "*/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
+find ${TARGET_DIR}/usr/lib/python3.12 -name '*.py' \
+	-not -path "*/python3.12/multiprocessing/connection.py" \
+	-not -path "*/python3.12/json/decoder.py" \
+	-not -path "*/python3.12/site-packages/numpy/core/_string_helpers.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/ccompiler.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/command/build_py.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/misc_util.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/system_info.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/auxfuncs.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/crackfortran.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/f2py2e.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/_iotools.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/npyio.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/recfunctions.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/stride_tricks.py" \
+	-not -path "*/python3.12/traceback.py" \
+	-not -path "*/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
 	-print0 | \
 	xargs -0 --no-run-if-empty rm -f
 

--- a/opt/pi02w-smartcard/board/post-build.sh
+++ b/opt/pi02w-smartcard/board/post-build.sh
@@ -13,76 +13,76 @@ rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
 # Clean up test files included with numpy
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/testing
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/linalg/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/typing/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/testing
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/linalg/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/typing/tests
 
 # Clean up files included in embit we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/embit/liquid
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/embit/liquid
 
 # Clean up tests/docs in other python included libs
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/pyzbar/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/qrcode/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/pyzbar/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/qrcode/tests
 
 # Clean up bigger python modules we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtle.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pydoc.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/doctest.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/mailbox.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtledemo
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/unittest
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/ensurepip
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtle.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pydoc.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/doctest.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/mailbox.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/zipfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/tarfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pickletools.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtledemo
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/unittest
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/ensurepip
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 
-rm -f ${TARGET_DIR}/usr/lib/python3.10/config-3.10-arm-linux-gnueabihf/Makefile
-rm -f ${TARGET_DIR}/usr/lib/python3.10/multiprocessing/connection.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/json/decoder.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/_string_helpers.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/ccompiler.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/command/build_py.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/misc_util.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/system_info.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/auxfuncs.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/crackfortran.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/f2py2e.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/_iotools.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/npyio.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/recfunctions.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/stride_tricks.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/traceback.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/config-3.12-arm-linux-gnueabihf/Makefile
+rm -f ${TARGET_DIR}/usr/lib/python3.12/multiprocessing/connection.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/json/decoder.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/_string_helpers.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/ccompiler.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/command/build_py.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/misc_util.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/system_info.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/auxfuncs.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/crackfortran.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/f2py2e.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/_iotools.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/npyio.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/recfunctions.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/stride_tricks.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/traceback.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
 
-find ${TARGET_DIR}/usr/lib/python3.10 -name '*.py' \
-	-not -path "*/python3.10/multiprocessing/connection.py" \
-	-not -path "*/python3.10/json/decoder.py" \
-	-not -path "*/python3.10/site-packages/numpy/core/_string_helpers.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/ccompiler.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/command/build_py.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/misc_util.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/system_info.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/auxfuncs.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/crackfortran.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/f2py2e.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/_iotools.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/npyio.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/recfunctions.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/stride_tricks.py" \
-	-not -path "*/python3.10/traceback.py" \
-	-not -path "*/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
+find ${TARGET_DIR}/usr/lib/python3.12 -name '*.py' \
+	-not -path "*/python3.12/multiprocessing/connection.py" \
+	-not -path "*/python3.12/json/decoder.py" \
+	-not -path "*/python3.12/site-packages/numpy/core/_string_helpers.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/ccompiler.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/command/build_py.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/misc_util.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/system_info.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/auxfuncs.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/crackfortran.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/f2py2e.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/_iotools.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/npyio.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/recfunctions.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/stride_tricks.py" \
+	-not -path "*/python3.12/traceback.py" \
+	-not -path "*/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
 	-print0 | \
 	xargs -0 --no-run-if-empty rm -f
 
 find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -f
 
 # Add python byte code (aka __pycache__ directories) to increase boot and import module speed
-SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.10 \
-  "${BUILD_DIR}/python3-3.10.10/Lib/compileall.py" \
+SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
+  "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"

--- a/opt/pi02w/board/post-build.sh
+++ b/opt/pi02w/board/post-build.sh
@@ -12,10 +12,8 @@ rm -f ${TARGET_DIR}/etc/init.d/S20seedrng
 rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
-# Adding symlink to support upgrade of buildroot python3.10 to python3.12
-ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3.10
+# Ensure python3 points to python3.12
 ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3
-ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3-3.10.10
 ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3
 
 # Clean up test files included with numpy

--- a/opt/pi2-dev/board/post-build.sh
+++ b/opt/pi2-dev/board/post-build.sh
@@ -17,10 +17,8 @@ console::respawn:-/bin/sh\
 tty1::respawn:-/bin/sh' ${TARGET_DIR}/etc/inittab
 fi
 
-# Adding symlink to support upgrade of buildroot python3.10 to python3.12
-ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3.10
+# Ensure python3 points to python3.12
 ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3
-ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3-3.10.10
 ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3
 
 # Clean up test files included with numpy

--- a/opt/pi2-smartcard-dev/board/post-build.sh
+++ b/opt/pi2-smartcard-dev/board/post-build.sh
@@ -26,67 +26,67 @@ rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
 # Clean up test files included with numpy
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/testing
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/linalg/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/typing/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/testing
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/linalg/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/typing/tests
 
 # Clean up files included in embit we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/embit/liquid
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/embit/liquid
 
 # Clean up tests/docs in other python included libs
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/pyzbar/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/qrcode/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/pyzbar/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/qrcode/tests
 
 # Clean up bigger python modules we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtle.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pydoc.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/doctest.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/mailbox.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtle.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pydoc.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/doctest.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/mailbox.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/zipfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/tarfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pickletools.pyc
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 
-rm -f ${TARGET_DIR}/usr/lib/python3.10/config-3.10-arm-linux-gnueabihf/Makefile
-rm -f ${TARGET_DIR}/usr/lib/python3.10/multiprocessing/connection.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/json/decoder.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/_string_helpers.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/ccompiler.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/command/build_py.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/misc_util.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/system_info.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/auxfuncs.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/crackfortran.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/f2py2e.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/_iotools.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/npyio.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/recfunctions.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/stride_tricks.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/traceback.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/config-3.12-arm-linux-gnueabihf/Makefile
+rm -f ${TARGET_DIR}/usr/lib/python3.12/multiprocessing/connection.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/json/decoder.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/_string_helpers.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/ccompiler.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/command/build_py.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/misc_util.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/system_info.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/auxfuncs.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/crackfortran.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/f2py2e.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/_iotools.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/npyio.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/recfunctions.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/stride_tricks.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/traceback.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
 
-find ${TARGET_DIR}/usr/lib/python3.10 -name '*.py' \
-	-not -path "*/python3.10/multiprocessing/connection.py" \
-	-not -path "*/python3.10/json/decoder.py" \
-	-not -path "*/python3.10/site-packages/numpy/core/_string_helpers.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/ccompiler.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/command/build_py.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/misc_util.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/system_info.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/auxfuncs.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/crackfortran.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/f2py2e.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/_iotools.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/npyio.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/recfunctions.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/stride_tricks.py" \
-	-not -path "*/python3.10/traceback.py" \
-	-not -path "*/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
+find ${TARGET_DIR}/usr/lib/python3.12 -name '*.py' \
+	-not -path "*/python3.12/multiprocessing/connection.py" \
+	-not -path "*/python3.12/json/decoder.py" \
+	-not -path "*/python3.12/site-packages/numpy/core/_string_helpers.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/ccompiler.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/command/build_py.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/misc_util.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/system_info.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/auxfuncs.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/crackfortran.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/f2py2e.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/_iotools.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/npyio.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/recfunctions.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/stride_tricks.py" \
+	-not -path "*/python3.12/traceback.py" \
+	-not -path "*/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
 	-print0 | \
 	xargs -0 --no-run-if-empty rm -f
 

--- a/opt/pi2-smartcard/board/post-build.sh
+++ b/opt/pi2-smartcard/board/post-build.sh
@@ -13,76 +13,76 @@ rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
 # Clean up test files included with numpy
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/testing
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/linalg/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/typing/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/testing
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/linalg/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/typing/tests
 
 # Clean up files included in embit we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/embit/liquid
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/embit/liquid
 
 # Clean up tests/docs in other python included libs
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/pyzbar/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/qrcode/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/pyzbar/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/qrcode/tests
 
 # Clean up bigger python modules we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtle.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pydoc.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/doctest.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/mailbox.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtledemo
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/unittest
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/ensurepip
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtle.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pydoc.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/doctest.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/mailbox.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/zipfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/tarfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pickletools.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtledemo
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/unittest
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/ensurepip
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 
-rm -f ${TARGET_DIR}/usr/lib/python3.10/config-3.10-arm-linux-gnueabihf/Makefile
-rm -f ${TARGET_DIR}/usr/lib/python3.10/multiprocessing/connection.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/json/decoder.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/_string_helpers.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/ccompiler.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/command/build_py.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/misc_util.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/system_info.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/auxfuncs.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/crackfortran.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/f2py2e.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/_iotools.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/npyio.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/recfunctions.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/stride_tricks.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/traceback.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/config-3.12-arm-linux-gnueabihf/Makefile
+rm -f ${TARGET_DIR}/usr/lib/python3.12/multiprocessing/connection.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/json/decoder.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/_string_helpers.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/ccompiler.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/command/build_py.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/misc_util.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/system_info.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/auxfuncs.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/crackfortran.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/f2py2e.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/_iotools.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/npyio.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/recfunctions.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/stride_tricks.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/traceback.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
 
-find ${TARGET_DIR}/usr/lib/python3.10 -name '*.py' \
-	-not -path "*/python3.10/multiprocessing/connection.py" \
-	-not -path "*/python3.10/json/decoder.py" \
-	-not -path "*/python3.10/site-packages/numpy/core/_string_helpers.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/ccompiler.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/command/build_py.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/misc_util.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/system_info.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/auxfuncs.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/crackfortran.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/f2py2e.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/_iotools.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/npyio.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/recfunctions.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/stride_tricks.py" \
-	-not -path "*/python3.10/traceback.py" \
-	-not -path "*/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
+find ${TARGET_DIR}/usr/lib/python3.12 -name '*.py' \
+	-not -path "*/python3.12/multiprocessing/connection.py" \
+	-not -path "*/python3.12/json/decoder.py" \
+	-not -path "*/python3.12/site-packages/numpy/core/_string_helpers.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/ccompiler.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/command/build_py.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/misc_util.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/system_info.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/auxfuncs.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/crackfortran.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/f2py2e.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/_iotools.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/npyio.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/recfunctions.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/stride_tricks.py" \
+	-not -path "*/python3.12/traceback.py" \
+	-not -path "*/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
 	-print0 | \
 	xargs -0 --no-run-if-empty rm -f
 
 find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -f
 
 # Add python byte code (aka __pycache__ directories) to increase boot and import module speed
-SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.10 \
-  "${BUILD_DIR}/python3-3.10.10/Lib/compileall.py" \
+SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
+  "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"

--- a/opt/pi2/board/post-build.sh
+++ b/opt/pi2/board/post-build.sh
@@ -12,10 +12,8 @@ rm -f ${TARGET_DIR}/etc/init.d/S20seedrng
 rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
-# Adding symlink to support upgrade of buildroot python3.10 to python3.12
-ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3.10
+# Ensure python3 points to python3.12
 ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3
-ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3-3.10.10
 ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3
 
 # Clean up test files included with numpy

--- a/opt/pi4-dev/board/post-build.sh
+++ b/opt/pi4-dev/board/post-build.sh
@@ -17,10 +17,8 @@ console::respawn:-/bin/sh\
 tty1::respawn:-/bin/sh' ${TARGET_DIR}/etc/inittab
 fi
 
-# Adding symlink to support upgrade of buildroot python3.10 to python3.12
-ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3.10
+# Ensure python3 points to python3.12
 ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3
-ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3-3.10.10
 ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3
 
 # Clean up test files included with numpy

--- a/opt/pi4-smartcard-dev/board/post-build.sh
+++ b/opt/pi4-smartcard-dev/board/post-build.sh
@@ -26,70 +26,70 @@ rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
 # Clean up test files included with numpy
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/testing
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/linalg/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/typing/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/testing
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/linalg/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/typing/tests
 
 # Clean up files included in embit we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/embit/liquid
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/embit/liquid
 
 # Clean up tests/docs in other python included libs
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/pyzbar/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/qrcode/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/pyzbar/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/qrcode/tests
 
 # Clean up bigger python modules we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtle.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pydoc.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/doctest.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/mailbox.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtledemo
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/unittest
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/ensurepip
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtle.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pydoc.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/doctest.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/mailbox.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/zipfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/tarfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pickletools.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtledemo
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/unittest
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/ensurepip
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 
-rm -f ${TARGET_DIR}/usr/lib/python3.10/config-3.10-arm-linux-gnueabihf/Makefile
-rm -f ${TARGET_DIR}/usr/lib/python3.10/multiprocessing/connection.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/json/decoder.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/_string_helpers.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/ccompiler.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/command/build_py.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/misc_util.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/system_info.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/auxfuncs.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/crackfortran.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/f2py2e.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/_iotools.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/npyio.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/recfunctions.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/stride_tricks.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/traceback.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/config-3.12-arm-linux-gnueabihf/Makefile
+rm -f ${TARGET_DIR}/usr/lib/python3.12/multiprocessing/connection.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/json/decoder.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/_string_helpers.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/ccompiler.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/command/build_py.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/misc_util.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/system_info.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/auxfuncs.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/crackfortran.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/f2py2e.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/_iotools.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/npyio.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/recfunctions.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/stride_tricks.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/traceback.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
 
-find ${TARGET_DIR}/usr/lib/python3.10 -name '*.py' \
-	-not -path "*/python3.10/multiprocessing/connection.py" \
-	-not -path "*/python3.10/json/decoder.py" \
-	-not -path "*/python3.10/site-packages/numpy/core/_string_helpers.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/ccompiler.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/command/build_py.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/misc_util.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/system_info.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/auxfuncs.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/crackfortran.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/f2py2e.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/_iotools.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/npyio.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/recfunctions.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/stride_tricks.py" \
-	-not -path "*/python3.10/traceback.py" \
-	-not -path "*/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
+find ${TARGET_DIR}/usr/lib/python3.12 -name '*.py' \
+	-not -path "*/python3.12/multiprocessing/connection.py" \
+	-not -path "*/python3.12/json/decoder.py" \
+	-not -path "*/python3.12/site-packages/numpy/core/_string_helpers.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/ccompiler.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/command/build_py.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/misc_util.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/system_info.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/auxfuncs.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/crackfortran.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/f2py2e.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/_iotools.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/npyio.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/recfunctions.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/stride_tricks.py" \
+	-not -path "*/python3.12/traceback.py" \
+	-not -path "*/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
 	-print0 | \
 	xargs -0 --no-run-if-empty rm -f
 

--- a/opt/pi4-smartcard/board/post-build.sh
+++ b/opt/pi4-smartcard/board/post-build.sh
@@ -13,76 +13,76 @@ rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
 # Clean up test files included with numpy
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/testing
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/linalg/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/typing/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/testing
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/linalg/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/typing/tests
 
 # Clean up files included in embit we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/embit/liquid
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/embit/liquid
 
 # Clean up tests/docs in other python included libs
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/pyzbar/tests
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/site-packages/qrcode/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/pyzbar/tests
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/site-packages/qrcode/tests
 
 # Clean up bigger python modules we don't need
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtle.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pydoc.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/doctest.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/mailbox.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/zipfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/tarfile.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/pickletools.pyc
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/turtledemo
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/unittest
-rm -rf ${TARGET_DIR}/usr/lib/python3.10/ensurepip
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtle.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pydoc.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/doctest.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/mailbox.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/zipfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/tarfile.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/pickletools.pyc
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/turtledemo
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/unittest
+rm -rf ${TARGET_DIR}/usr/lib/python3.12/ensurepip
 
 # ### Reproducibility experimentation
 # ### Remove all pyc files I can seem to make reproducible and keep the py versions
 
-rm -f ${TARGET_DIR}/usr/lib/python3.10/config-3.10-arm-linux-gnueabihf/Makefile
-rm -f ${TARGET_DIR}/usr/lib/python3.10/multiprocessing/connection.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/json/decoder.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/core/_string_helpers.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/ccompiler.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/command/build_py.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/misc_util.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/distutils/system_info.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/auxfuncs.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/crackfortran.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/f2py/f2py2e.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/_iotools.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/npyio.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/recfunctions.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/site-packages/numpy/lib/stride_tricks.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/traceback.pyc
-rm -f ${TARGET_DIR}/usr/lib/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/config-3.12-arm-linux-gnueabihf/Makefile
+rm -f ${TARGET_DIR}/usr/lib/python3.12/multiprocessing/connection.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/json/decoder.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/core/_string_helpers.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/ccompiler.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/command/build_py.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/misc_util.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/distutils/system_info.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/auxfuncs.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/crackfortran.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/f2py/f2py2e.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/_iotools.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/npyio.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/recfunctions.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/site-packages/numpy/lib/stride_tricks.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/traceback.pyc
+rm -f ${TARGET_DIR}/usr/lib/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.pyc
 
-find ${TARGET_DIR}/usr/lib/python3.10 -name '*.py' \
-	-not -path "*/python3.10/multiprocessing/connection.py" \
-	-not -path "*/python3.10/json/decoder.py" \
-	-not -path "*/python3.10/site-packages/numpy/core/_string_helpers.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/ccompiler.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/command/build_py.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/misc_util.py" \
-	-not -path "*/python3.10/site-packages/numpy/distutils/system_info.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/auxfuncs.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/crackfortran.py" \
-	-not -path "*/python3.10/site-packages/numpy/f2py/f2py2e.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/_iotools.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/npyio.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/recfunctions.py" \
-	-not -path "*/python3.10/site-packages/numpy/lib/stride_tricks.py" \
-	-not -path "*/python3.10/traceback.py" \
-	-not -path "*/python3.10/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
+find ${TARGET_DIR}/usr/lib/python3.12 -name '*.py' \
+	-not -path "*/python3.12/multiprocessing/connection.py" \
+	-not -path "*/python3.12/json/decoder.py" \
+	-not -path "*/python3.12/site-packages/numpy/core/_string_helpers.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/ccompiler.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/command/build_py.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/misc_util.py" \
+	-not -path "*/python3.12/site-packages/numpy/distutils/system_info.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/auxfuncs.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/crackfortran.py" \
+	-not -path "*/python3.12/site-packages/numpy/f2py/f2py2e.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/_iotools.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/npyio.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/recfunctions.py" \
+	-not -path "*/python3.12/site-packages/numpy/lib/stride_tricks.py" \
+	-not -path "*/python3.12/traceback.py" \
+	-not -path "*/python3.12/_sysconfigdata__linux_arm-linux-gnueabihf.py" \
 	-print0 | \
 	xargs -0 --no-run-if-empty rm -f
 
 find "${TARGET_DIR}" -name '.DS_Store' -print0 | xargs -0 --no-run-if-empty rm -f
 
 # Add python byte code (aka __pycache__ directories) to increase boot and import module speed
-SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.10 \
-  "${BUILD_DIR}/python3-3.10.10/Lib/compileall.py" \
+SOURCE_DATE_EPOCH=1 PYTHONHASHSEED=0 ${HOST_DIR}/bin/python3.12 \
+  "${BUILD_DIR}/python3-3.12.10/Lib/compileall.py" \
   -f --invalidation-mode=checked-hash "${TARGET_DIR}/opt/src"

--- a/opt/pi4/board/post-build.sh
+++ b/opt/pi4/board/post-build.sh
@@ -12,10 +12,8 @@ rm -f ${TARGET_DIR}/etc/init.d/S20seedrng
 rm -f ${TARGET_DIR}/etc/init.d/S40network
 rm -f ${TARGET_DIR}/etc/init.d/S50pigpio
 
-# Adding symlink to support upgrade of buildroot python3.10 to python3.12
-ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3.10
+# Ensure python3 points to python3.12
 ln -srf ${TARGET_DIR}/usr/lib/python3.12 ${TARGET_DIR}/usr/lib/python3
-ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3-3.10.10
 ln -srf ${BUILD_DIR}/python3-3.12.10 ${BUILD_DIR}/python3
 
 # Clean up test files included with numpy


### PR DESCRIPTION
## Summary
- update all post-build scripts to target Python 3.12
- drop legacy python3.10 symlinks

## Testing
- `for f in opt/*/board/post-build.sh opt/*-smartcard/board/post-build.sh opt/*-smartcard-dev/board/post-build.sh opt/*-dev/board/post-build.sh; do bash -n "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68bb6dbdd4f483228922b22fe18afd5d