### PR TITLE
Merge upstream changes (0.8.7)

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -74,6 +74,23 @@ SS_ARGS="--$BOARD_TYPE --app-branch=$RELEASE_TAG" docker compose up --force-recr
 <p>
 *Note: We recommend running these steps in WSL2 (Windows Subsystem for Linux) instead of PowerShell so that you can just follow the macOS / Linux steps above.*
 
+#### Windows prerequisites (PowerShell)
+These must be set **before cloning** the repo. If you already cloned, reclone after setting these.
+
+1) Enable **Developer Mode** in Windows (Settings → System → For Developers → Developer Mode) so Git can create symlinks.
+
+2) Configure Git to preserve LF line endings and symlinks:
+```powershell
+git config --global core.autocrlf false
+git config --global core.eol lf
+git config --global core.symlinks true
+```
+
+Optional: verify the GCC hash file is a symlink after submodules are initialized:
+```powershell
+Get-Item opt/buildroot/package/gcc/gcc-initial/gcc-initial.hash | Select-Object LinkType,Target
+```
+
 #### Configure environment variables
 Force Docker to build on a container meant to run on amd64 in order to get an identical result, even if your actual cpu is different:
 
@@ -129,6 +146,8 @@ seedsigner-os-build-images-1 exited with code 0
 ```
 
 The second line above will show the SHA256 hash of the image file that was built. This hash should match the hash of the release image [published on the main github repo](https://github.com/SeedSigner/seedsigner/releases) for the chosen `RELEASE_TAG` + `BOARD_TYPE` combo. If the hashes match, then you have successfully confirmed the reproducible build!
+
+**Windows (PowerShell) note:** Even with LF line endings and symlinks enabled, some Windows builds may still produce a different image hash than the published release. WSL2 remains the recommended path for reproducible builds.
 
 The completed image file will be in the `images` subdirectory.
 ```bash

--- a/docs/dev_workflow.md
+++ b/docs/dev_workflow.md
@@ -2,6 +2,11 @@
 
 Each time the `docker compose up` command runs, a full build from scratch is performed. You can optionally run `docker compose up -d` in detached mode by adding the `-d` flag. This will run the container in the background. To have faster development cycles you'll likely want to avoid building the OS from scratch each time. To avoid recreating the docker image/container each time, you have a few different routes. One such route is to pass the options `--no-op` (which is the default) to the `SS_ARGS` env variable when running `docker-compose up`. This will cause the container to skip the build steps but keep the container running in the background until you explicitly stop it. You can then launch a shell session into the container and work interactively, running any specific build commands you desire.
 
+First make sure that the submodules are in sync:
+```bash
+git submodule update --recursive
+```
+
 Using docker compose will start the container (create new container if one does not already exist) without building an image
 ```bash
 SS_ARGS="--no-op" docker compose up -d --no-recreate

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -58,11 +58,12 @@ compile_translations_and_fonts() {
   # generate messages.mo files for each translation
   python3 setup.py compile_catalog || exit
 
-
   # extract characters from all messages.mo translations into all_chars shell variable
   all_chars=""
-  for f in "${ss_translations_repo}/l10n/"**"/LC_MESSAGES/messages.mo"; do
-    output_chars=$(python3 ${ss_translations_repo}/tools/extract_characters_from_babel_mo.py $f)
+  for f in ${ss_translations_repo}/l10n/*/LC_MESSAGES/messages.mo; do
+    # extract just the locale name from the path (e.g. "ca" from ".../l10n/ca/LC_MESSAGES/messages.mo")
+    locale=$(basename "$(dirname "$(dirname "$f")")")
+    output_chars=$(cd ${ss_translations_repo}/tools && python3 extract_characters_from_babel_mo.py "$locale")
     all_chars="${all_chars}${output_chars}"
   done
 

--- a/opt/build.sh
+++ b/opt/build.sh
@@ -63,7 +63,7 @@ compile_translations_and_fonts() {
   for f in ${ss_translations_repo}/l10n/*/LC_MESSAGES/messages.mo; do
     # extract just the locale name from the path (e.g. "ca" from ".../l10n/ca/LC_MESSAGES/messages.mo")
     locale=$(basename "$(dirname "$(dirname "$f")")")
-    output_chars=$(cd ${ss_translations_repo}/tools && python3 extract_characters_from_babel_mo.py "$locale")
+    output_chars=$(cd ${ss_translations_repo}/tools && python3 extract_characters_from_babel_mo.py "$locale") || echo "Warning: failed to extract chars for locale: $locale" >&2
     all_chars="${all_chars}${output_chars}"
   done
 


### PR DESCRIPTION
This pull request introduces improvements to the build workflow and documentation, focusing on better support for Windows users and optimizing the handling of translations and font files during the build process. The most significant changes are the extraction of translation/font compilation into a dedicated function, enhanced documentation for Windows prerequisites, and improved submodule handling.

**Build process improvements:**

* Added a new `compile_translations_and_fonts` function in `opt/build.sh` to handle compiling translation files and slimming font files, including setting up a virtual environment, installing dependencies, compiling `.mo` files, extracting used characters, and subsetting font files to reduce their size.
* Updated `download_app_repo` in `opt/build.sh` to call `compile_translations_and_fonts` and ensure submodules are updated after checkout, improving reliability and modularity.

**Documentation updates for Windows support:**

* Added a new "Windows prerequisites (PowerShell)" section to `docs/building.md`, detailing required Git settings and developer mode for correct symlink and line ending handling, plus a verification step for symlinks.
* Added a note in `docs/building.md` clarifying that Windows builds may still produce different image hashes, and recommending WSL2 for reproducible builds.

**Developer workflow improvements:**

* Updated `docs/dev_workflow.md` to remind developers to sync submodules before starting development, preventing potential issues.