### PR TITLE
Add testing-build marker wiring, off by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,9 @@ services:
       # Off unless explicitly set to "1" -- see post-build.sh in each
       # *-smartcard* profile and opt/luckfox/{os-build,build-local}.sh.
       - SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS
+      # Off unless explicitly set to "1" -- see post-build.sh in each
+      # *-smartcard* profile and opt/luckfox/{os-build,build-local}.sh. Ships
+      # the marker that swaps Home's menu for the hardware test menu (see
+      # seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+      - SEEDSIGNER_TESTING_BUILD
     command: "${SS_ARGS:---no-op}"

--- a/opt/lafrite-smartcard-dev/board/post-build.sh
+++ b/opt/lafrite-smartcard-dev/board/post-build.sh
@@ -84,3 +84,11 @@ if [ "${SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS:-0}" = "1" ]; then
     mkdir -p "${TARGET_DIR}/etc"
     touch "${TARGET_DIR}/etc/seedsigner-error-microsd-export"
 fi
+
+# Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in the
+# build environment, ship the marker that swaps Home's menu for the hardware
+# test menu (see seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+    mkdir -p "${TARGET_DIR}/etc"
+    touch "${TARGET_DIR}/etc/seedsigner-testing-build"
+fi

--- a/opt/lafrite-smartcard/board/post-build.sh
+++ b/opt/lafrite-smartcard/board/post-build.sh
@@ -63,3 +63,11 @@ if [ "${SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS:-0}" = "1" ]; then
     mkdir -p "${TARGET_DIR}/etc"
     touch "${TARGET_DIR}/etc/seedsigner-error-microsd-export"
 fi
+
+# Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in the
+# build environment, ship the marker that swaps Home's menu for the hardware
+# test menu (see seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+    mkdir -p "${TARGET_DIR}/etc"
+    touch "${TARGET_DIR}/etc/seedsigner-testing-build"
+fi

--- a/opt/luckfox/build-local.sh
+++ b/opt/luckfox/build-local.sh
@@ -1431,6 +1431,15 @@ install_seedsigner_app() {
         touch "$rootfs_dir/etc/seedsigner-error-microsd-export"
     fi
 
+    # Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in
+    # the build environment, ship the marker that swaps Home's menu for the
+    # hardware test menu (see seedsigner repo: helpers/seedsigner_os.py
+    # is_testing_build_enabled()).
+    if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+        mkdir -p "$rootfs_dir/etc"
+        touch "$rootfs_dir/etc/seedsigner-testing-build"
+    fi
+
     # Patch settings.json for Mini hardware
     if [ "$hardware" == "mini" ]; then
         local settings_json="$rootfs_dir/opt/src/settings.json"

--- a/opt/luckfox/os-build.sh
+++ b/opt/luckfox/os-build.sh
@@ -1459,6 +1459,15 @@ s/^endef\nendif/endef\nendif\nendif/
         touch "$ROOTFS_DIR/etc/seedsigner-error-microsd-export"
     fi
 
+    # Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in
+    # the build environment, ship the marker that swaps Home's menu for the
+    # hardware test menu (see seedsigner repo: helpers/seedsigner_os.py
+    # is_testing_build_enabled()).
+    if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+        mkdir -p "$ROOTFS_DIR/etc"
+        touch "$ROOTFS_DIR/etc/seedsigner-testing-build"
+    fi
+
     print_step "Installing SeedSigner Support Files"
     local luckfox_cfg_template="/build/files/luckfox-${board_profile}.cfg"
     if [[ -f "$luckfox_cfg_template" ]]; then

--- a/opt/pi0-smartcard-dev/board/post-build.sh
+++ b/opt/pi0-smartcard-dev/board/post-build.sh
@@ -76,3 +76,11 @@ if [ "${SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS:-0}" = "1" ]; then
     mkdir -p "${TARGET_DIR}/etc"
     touch "${TARGET_DIR}/etc/seedsigner-error-microsd-export"
 fi
+
+# Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in the
+# build environment, ship the marker that swaps Home's menu for the hardware
+# test menu (see seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+    mkdir -p "${TARGET_DIR}/etc"
+    touch "${TARGET_DIR}/etc/seedsigner-testing-build"
+fi

--- a/opt/pi0-smartcard/board/post-build.sh
+++ b/opt/pi0-smartcard/board/post-build.sh
@@ -99,3 +99,11 @@ if [ "${SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS:-0}" = "1" ]; then
     mkdir -p "${TARGET_DIR}/etc"
     touch "${TARGET_DIR}/etc/seedsigner-error-microsd-export"
 fi
+
+# Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in the
+# build environment, ship the marker that swaps Home's menu for the hardware
+# test menu (see seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+    mkdir -p "${TARGET_DIR}/etc"
+    touch "${TARGET_DIR}/etc/seedsigner-testing-build"
+fi

--- a/opt/pi02w-smartcard-dev/board/post-build.sh
+++ b/opt/pi02w-smartcard-dev/board/post-build.sh
@@ -76,3 +76,11 @@ if [ "${SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS:-0}" = "1" ]; then
     mkdir -p "${TARGET_DIR}/etc"
     touch "${TARGET_DIR}/etc/seedsigner-error-microsd-export"
 fi
+
+# Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in the
+# build environment, ship the marker that swaps Home's menu for the hardware
+# test menu (see seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+    mkdir -p "${TARGET_DIR}/etc"
+    touch "${TARGET_DIR}/etc/seedsigner-testing-build"
+fi

--- a/opt/pi02w-smartcard/board/post-build.sh
+++ b/opt/pi02w-smartcard/board/post-build.sh
@@ -99,3 +99,11 @@ if [ "${SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS:-0}" = "1" ]; then
     mkdir -p "${TARGET_DIR}/etc"
     touch "${TARGET_DIR}/etc/seedsigner-error-microsd-export"
 fi
+
+# Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in the
+# build environment, ship the marker that swaps Home's menu for the hardware
+# test menu (see seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+    mkdir -p "${TARGET_DIR}/etc"
+    touch "${TARGET_DIR}/etc/seedsigner-testing-build"
+fi

--- a/opt/pi2-smartcard-dev/board/post-build.sh
+++ b/opt/pi2-smartcard-dev/board/post-build.sh
@@ -76,3 +76,11 @@ if [ "${SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS:-0}" = "1" ]; then
     mkdir -p "${TARGET_DIR}/etc"
     touch "${TARGET_DIR}/etc/seedsigner-error-microsd-export"
 fi
+
+# Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in the
+# build environment, ship the marker that swaps Home's menu for the hardware
+# test menu (see seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+    mkdir -p "${TARGET_DIR}/etc"
+    touch "${TARGET_DIR}/etc/seedsigner-testing-build"
+fi

--- a/opt/pi2-smartcard/board/post-build.sh
+++ b/opt/pi2-smartcard/board/post-build.sh
@@ -99,3 +99,11 @@ if [ "${SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS:-0}" = "1" ]; then
     mkdir -p "${TARGET_DIR}/etc"
     touch "${TARGET_DIR}/etc/seedsigner-error-microsd-export"
 fi
+
+# Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in the
+# build environment, ship the marker that swaps Home's menu for the hardware
+# test menu (see seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+    mkdir -p "${TARGET_DIR}/etc"
+    touch "${TARGET_DIR}/etc/seedsigner-testing-build"
+fi

--- a/opt/pi4-smartcard-dev/board/post-build.sh
+++ b/opt/pi4-smartcard-dev/board/post-build.sh
@@ -76,3 +76,11 @@ if [ "${SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS:-0}" = "1" ]; then
     mkdir -p "${TARGET_DIR}/etc"
     touch "${TARGET_DIR}/etc/seedsigner-error-microsd-export"
 fi
+
+# Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in the
+# build environment, ship the marker that swaps Home's menu for the hardware
+# test menu (see seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+    mkdir -p "${TARGET_DIR}/etc"
+    touch "${TARGET_DIR}/etc/seedsigner-testing-build"
+fi

--- a/opt/pi4-smartcard/board/post-build.sh
+++ b/opt/pi4-smartcard/board/post-build.sh
@@ -99,3 +99,11 @@ if [ "${SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS:-0}" = "1" ]; then
     mkdir -p "${TARGET_DIR}/etc"
     touch "${TARGET_DIR}/etc/seedsigner-error-microsd-export"
 fi
+
+# Testing build, off by default: when SEEDSIGNER_TESTING_BUILD=1 is set in the
+# build environment, ship the marker that swaps Home's menu for the hardware
+# test menu (see seedsigner repo: helpers/seedsigner_os.py is_testing_build_enabled()).
+if [ "${SEEDSIGNER_TESTING_BUILD:-0}" = "1" ]; then
+    mkdir -p "${TARGET_DIR}/etc"
+    touch "${TARGET_DIR}/etc/seedsigner-testing-build"
+fi


### PR DESCRIPTION
## Summary
- Ships `/etc/seedsigner-testing-build` when `SEEDSIGNER_TESTING_BUILD=1` is set in the build environment, mirroring the existing `SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS` pattern exactly.
- Forwarded through `docker-compose.yml`, applied in each Buildroot board's `post-build.sh` (pi0/pi02w/pi2/pi4/lafrite × smartcard/smartcard-dev), and both Luckfox build scripts (`opt/luckfox/os-build.sh`, `opt/luckfox/build-local.sh`).
- Off by default — no behavior change unless the env var is explicitly set.
- Companion PR in seedsigner reads this marker (`helpers/seedsigner_os.py::is_testing_build_enabled()`) to swap Home's menu for a hardware bring-up set (I/O Test, Test Smartcard, Flash Applet, Settings).

## Test plan
- [x] `bash -n` syntax-checked all 12 modified shell scripts.
- [x] CI: `build-buildroot.yml` in the seedsigner repo, built against this branch + the seedsigner `testing-build` branch, both `dev: true` and `dev: false`, `smartcard: true`, `testing-build: true` — both builds succeeded:
  - https://github.com/3rdIteration/seedsigner/actions/runs/31753692038 (dev)
  - https://github.com/3rdIteration/seedsigner/actions/runs/31760931818 (non-dev)
- [ ] Confirm `/etc/seedsigner-testing-build` is present in the built image's rootfs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)